### PR TITLE
[chore] PWA 초기설정

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -32,3 +32,5 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+certificates

--- a/apps/web/app/apple-icon.tsx
+++ b/apps/web/app/apple-icon.tsx
@@ -1,0 +1,57 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+
+export const size = {
+  width: 180,
+  height: 180,
+};
+
+export const contentType = 'image/png';
+
+const AppleIcon = () => {
+  const size = 180; // 아이콘 크기
+  const iconSize = Math.floor(size * 0.6); // 108px
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          fontSize: 48,
+          background: 'linear-gradient(135deg, #5758FE 0%, #2E29A0 100%)',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'white',
+          borderRadius: '22%', // iOS 스타일 둥근 모서리
+        }}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={iconSize}
+          height={iconSize}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="lucide lucide-gavel-icon lucide-gavel"
+        >
+          <path d="m14.5 12.5-8 8a2.119 2.119 0 1 1-3-3l8-8" />
+          <path d="m16 16 6-6" />
+          <path d="m8 8 6-6" />
+          <path d="m9 7 8 8" />
+          <path d="m21 11-8-8" />
+        </svg>
+      </div>
+    ),
+    {
+      width: size,
+      height: size,
+    }
+  );
+};
+
+export default AppleIcon;

--- a/apps/web/app/icon.tsx
+++ b/apps/web/app/icon.tsx
@@ -1,0 +1,72 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+//
+export const generateImageMetadata = () => {
+  return [
+    {
+      contentType: 'image/png',
+      size: { width: 32, height: 32 },
+      id: 'small',
+    },
+    {
+      contentType: 'image/png',
+      size: { width: 192, height: 192 },
+      id: 'medium',
+    },
+    {
+      contentType: 'image/png',
+      size: { width: 512, height: 512 },
+      id: 'large',
+    },
+  ];
+};
+
+const Icon = ({ id }: { id: string }) => {
+  // id에 따라 크기 결정
+  const size = id === 'large' ? 512 : id === 'medium' ? 192 : 32;
+  const iconSize = Math.floor(size * 0.6); // 아이콘 크기를 전체의 60%로 설정
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          fontSize: size * 0.75,
+          background: size >= 180 ? 'linear-gradient(135deg, #5758FE 0%, #2E29A0 100%)' : '#5758FE',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'white',
+          borderRadius: size >= 180 ? '22%' : '20%',
+        }}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={iconSize}
+          height={iconSize}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="lucide lucide-gavel-icon lucide-gavel"
+        >
+          <path d="m14.5 12.5-8 8a2.119 2.119 0 1 1-3-3l8-8" />
+          <path d="m16 16 6-6" />
+          <path d="m8 8 6-6" />
+          <path d="m9 7 8 8" />
+          <path d="m21 11-8-8" />
+        </svg>
+      </div>
+    ),
+    {
+      width: size,
+      height: size,
+    }
+  );
+};
+
+export default Icon;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,22 +1,66 @@
 import { Inter } from 'next/font/google';
 
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 
-import { QueryProvider } from '~shared/lib/providers/query-provider';
+import ClientLayout from '@/src/shared/ui/layout/client-layout';
 import './globals.css';
 
-const inter = Inter({ subsets: ['latin'] });
+const inter = Inter({ subsets: ['latin'], display: 'swap' });
 
+const APP_NAME = '지역 경매 서비스';
+const APP_DEFAULT_TITLE = '지역 경매 서비스';
+const APP_TITLE_TEMPLATE = '%s - 경매앱';
+const APP_DESCRIPTION = '지역 기반 실시간 경매 플랫폼';
+
+// 클라이언트 컴포넌트와 서버 컴포넌트 분리
 export const metadata: Metadata = {
-  title: '지역기반 경매 서비스',
-  description: 'Geo-based auction platform',
+  applicationName: APP_NAME,
+  title: {
+    default: APP_DEFAULT_TITLE,
+    template: APP_TITLE_TEMPLATE,
+  },
+  description: APP_DESCRIPTION,
+  manifest: '/manifest.webmanifest',
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: 'default',
+    title: APP_DEFAULT_TITLE,
+  },
+  formatDetection: {
+    telephone: false,
+  },
+  openGraph: {
+    type: 'website',
+    siteName: APP_NAME,
+    title: {
+      default: APP_DEFAULT_TITLE,
+      template: APP_TITLE_TEMPLATE,
+    },
+    description: APP_DESCRIPTION,
+  },
+  twitter: {
+    card: 'summary',
+    title: {
+      default: APP_DEFAULT_TITLE,
+      template: APP_TITLE_TEMPLATE,
+    },
+    description: APP_DESCRIPTION,
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: '#5758FE',
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
 };
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang="ko">
-      <body className={inter.className}>
-        <QueryProvider>{children}</QueryProvider>
+      <body className={inter.className} suppressHydrationWarning>
+        <ClientLayout>{children}</ClientLayout>
       </body>
     </html>
   );

--- a/apps/web/app/manifest.ts
+++ b/apps/web/app/manifest.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from 'next';
+
+const manifest = (): MetadataRoute.Manifest => {
+  return {
+    name: '지역 경매 서비스',
+    short_name: '경매앱',
+    description: '지역 기반 실시간 경매 플랫폼',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#ffffff', // 로딩 시 배경색
+    theme_color: '#5758FE', // 브라우저 UI 색상
+    icons: [
+      {
+        // generateImageMetadata의 medium id 참조
+        src: '/icon/medium',
+        sizes: '192x192',
+        type: 'image/png',
+      },
+      {
+        src: '/icon/large',
+        sizes: '512x512',
+        type: 'image/png',
+      },
+    ],
+  };
+};
+
+export default manifest;

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,7 +1,10 @@
-import { HomePage } from '~pages/home';
+// /apps/web/app/page.tsx
+'use client';
+
+import { PWATest } from '../src/shared/ui/pwa-test';
 
 const Page = () => {
-  return <HomePage />;
+  return <PWATest />;
 };
 
 export default Page;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from 'next';
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  optimizeFonts: true, // 기본값은 true
+};
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^19.1.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
+    "web-push": "^3.6.7",
     "zustand": "^5.0.5"
   },
   "devDependencies": {
@@ -34,6 +35,7 @@
     "@types/node": "^22.15.3",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.1",
+    "@types/web-push": "^3.6.4",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.28.0",
     "postcss": "^8.5.3",

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,0 +1,53 @@
+self.addEventListener('push', function (event) {
+  if (event.data) {
+    try {
+      const data = event.data.json();
+      const options = {
+        body: data.body,
+        // icon2.tsx는 Next.js가 인식하는 파일명 (크기에 따라 적절한 아이콘 선택)
+        icon: data.icon || '/icon/medium',
+        badge: '/icon/small',
+        vibrate: [100, 50, 100],
+        data: {
+          dateOfArrival: Date.now(),
+          primaryKey: '2',
+        },
+      };
+      event.waitUntil(self.registration.showNotification(data.title, options));
+    } catch (error) {
+      console.error('알림 데이터 처리 중 오류 발생:', error);
+
+      // JSON 파싱에 실패한 경우 텍스트 데이터 그대로 사용
+      const textData = event.data ? event.data.text() : '새로운 알림';
+
+      event.waitUntil(
+        self.registration.showNotification('알림', {
+          body: `${textData}`, // 파싱 실패한 원본 텍스트를 본문으로 사용
+          icon: '/icon/medium',
+          badge: '/icon/small',
+          vibrate: [100, 50, 100],
+        })
+      );
+    }
+  } else {
+    console.log('푸시 이벤트에 데이터가 없습니다.');
+    event.waitUntil(
+      self.registration.showNotification('알림', {
+        body: '새로운 알림이 도착했습니다.',
+        icon: '/icon/medium',
+        badge: '/icon/small',
+        vibrate: [100, 50, 100],
+      })
+    );
+  }
+});
+
+// 추가
+self.addEventListener('error', function (event) {
+  console.error('Service Worker 오류:', event.error);
+});
+
+self.addEventListener('unhandledrejection', function (event) {
+  console.error('처리되지 않은 Promise 거부:', event.reason);
+  event.preventDefault();
+});

--- a/apps/web/src/shared/lib/actions/push-notification.ts
+++ b/apps/web/src/shared/lib/actions/push-notification.ts
@@ -1,0 +1,46 @@
+'use server';
+
+import webpush from 'web-push';
+
+webpush.setVapidDetails(
+  'mailto:support@yourcompany.com',
+  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!,
+  process.env.VAPID_PRIVATE_KEY!
+);
+
+let subscription: webpush.PushSubscription | null = null;
+
+export const subscribeUser = async (sub: webpush.PushSubscription) => {
+  subscription = sub;
+  // 실제 환경에서는 데이터베이스에 저장
+  // 예: await db.subscriptions.create({ data: sub })
+  return { success: true };
+};
+
+export const unsubscribeUser = async () => {
+  subscription = null;
+  // 실제 환경에서는 데이터베이스에서 삭제
+  // 예: await db.subscriptions.delete({ where: { ... } })
+  return { success: true };
+};
+
+export const sendNotification = async (message: string) => {
+  if (!subscription) {
+    throw new Error('구독 정보가 없습니다');
+  }
+
+  try {
+    await webpush.sendNotification(
+      subscription,
+      JSON.stringify({
+        title: '경매 알림', // 알림 제목
+        body: message, // 알림 내용
+        icon: '/icon/medium', // 알림 아이콘
+      })
+    );
+    return { success: true };
+  } catch (error) {
+    console.error('푸시 알림 전송 실패:', error);
+    return { success: false, error: '알림 전송에 실패했습니다' };
+  }
+};

--- a/apps/web/src/shared/ui/layout/client-layout.tsx
+++ b/apps/web/src/shared/ui/layout/client-layout.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { QueryProvider } from '~shared/lib/providers/query-provider';
+
+const ClientLayout = ({ children }: { children: React.ReactNode }) => {
+  return <QueryProvider>{children}</QueryProvider>;
+};
+
+export default ClientLayout;

--- a/apps/web/src/shared/ui/pwa-test/index.ts
+++ b/apps/web/src/shared/ui/pwa-test/index.ts
@@ -1,0 +1,1 @@
+export { default as PWATest } from './pwa-test';

--- a/apps/web/src/shared/ui/pwa-test/pwa-test.tsx
+++ b/apps/web/src/shared/ui/pwa-test/pwa-test.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import {
+  sendNotification,
+  subscribeUser,
+  unsubscribeUser,
+} from '@/src/shared/lib/actions/push-notification';
+
+const urlBase64ToUint8Array = (base64String: string) => {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = window.atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+};
+
+const PWATest = () => {
+  const [isSupported, setIsSupported] = useState(false);
+  const [subscription, setSubscription] = useState<PushSubscription | null>(null);
+  const [message, setMessage] = useState('');
+  const [browserInfo, setBrowserInfo] = useState(''); // 사파리 브라우저 감지
+
+  useEffect(() => {
+    // 브라우저 감지
+    const userAgent = navigator.userAgent;
+    const isSafari = /^((?!chrome|android).)*safari/i.test(userAgent); // 사파리 브라우저 감지
+    const isIOS = /iPad|iPhone|iPod/.test(userAgent); // iOS 디바이스 감지
+
+    setBrowserInfo(isSafari ? 'Safari' : isIOS ? 'iOS' : 'Chrome');
+
+    if ('serviceWorker' in navigator && 'PushManager' in window) {
+      // 사파리에서는 푸시 알림 지원 확인
+      if (isSafari || isIOS) {
+        // 사파리/iOS는 PWA로 설치된 경우에만 푸시 알림 지원
+        const isStandalone = window.matchMedia('(display-mode: standalone)').matches;
+        if (!isStandalone) {
+          console.warn('사파리에서는 홈 화면에 설치 후 푸시 알림 사용 가능');
+          setIsSupported(false);
+          return;
+        }
+      }
+
+      setIsSupported(true);
+      registerServiceWorker();
+    }
+  }, []);
+
+  const registerServiceWorker = async () => {
+    const registration = await navigator.serviceWorker.register('/sw.js', {
+      scope: '/',
+      updateViaCache: 'none',
+    });
+    const sub = await registration.pushManager.getSubscription();
+    setSubscription(sub);
+  };
+
+  const subscribeToPush = async () => {
+    const registration = await navigator.serviceWorker.ready;
+    const sub = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!),
+    });
+    setSubscription(sub);
+    const serializedSub = JSON.parse(JSON.stringify(sub));
+    await subscribeUser(serializedSub);
+  };
+
+  const unsubscribeFromPush = async () => {
+    await subscription?.unsubscribe();
+    setSubscription(null);
+    await unsubscribeUser();
+  };
+
+  const sendTestNotification = async () => {
+    if (subscription) {
+      await sendNotification(message);
+      setMessage('');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="container mx-auto px-4">
+        <h1 className="mb-8 text-center text-3xl font-bold">🧪 PWA 테스트 페이지</h1>
+
+        {/* ✅ 브라우저 정보 표시 */}
+        <div className="mx-auto mb-6 max-w-md rounded-lg border bg-white p-6 shadow">
+          <h2 className="mb-4 text-lg font-semibold">🌐 브라우저 정보</h2>
+          <p className="text-sm text-gray-600">현재 브라우저: {browserInfo}</p>
+          {browserInfo === 'Safari' && (
+            <p className="mt-2 text-sm text-orange-600">
+              ⚠️ 사파리에서는 홈 화면에 설치 후 푸시 알림 사용 가능합니다.
+            </p>
+          )}
+        </div>
+
+        {/* PWA 설치 테스트 */}
+        <div className="mx-auto mb-6 max-w-md rounded-lg border bg-white p-6 shadow">
+          <h2 className="mb-4 text-lg font-semibold">📱 PWA 설치</h2>
+          <p className="mb-4 text-sm text-gray-600">Chrome 주소창에서 설치 아이콘을 찾아보세요!</p>
+        </div>
+
+        {/* 푸시 알림 테스트 */}
+        <div className="mx-auto max-w-md rounded-lg border bg-white p-6 shadow">
+          <h2 className="mb-4 text-lg font-semibold">🔔 푸시 알림</h2>
+
+          {!isSupported ? (
+            <p className="text-red-600">이 브라우저는 푸시 알림을 지원하지 않습니다.</p>
+          ) : subscription ? (
+            <div className="space-y-4">
+              <p className="text-sm text-green-600">✅ 푸시 알림이 활성화되었습니다.</p>
+              <button
+                onClick={unsubscribeFromPush}
+                className="w-full rounded bg-red-600 px-4 py-2 text-white hover:bg-red-700"
+              >
+                구독 해제
+              </button>
+              <div>
+                <input
+                  type="text"
+                  placeholder="테스트 메시지를 입력하세요"
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  className="mb-2 w-full rounded border border-gray-300 px-3 py-2"
+                />
+                <button
+                  onClick={sendTestNotification}
+                  className="w-full rounded bg-purple-600 px-4 py-2 text-white hover:bg-purple-700"
+                >
+                  🚀 테스트 알림 보내기
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <p className="text-sm text-gray-600">푸시 알림이 비활성화되어 있습니다.</p>
+              <button
+                onClick={subscribeToPush}
+                className="w-full rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+              >
+                🔔 알림 구독하기
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PWATest;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.1.5)
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zustand:
         specifier: ^5.0.5
         version: 5.0.5(@types/react@19.1.0)(react@19.1.0)
@@ -178,6 +181,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.1
         version: 19.1.1(@types/react@19.1.0)
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.5.3)
@@ -3324,6 +3330,12 @@ packages:
     resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
     dev: true
 
+  /@types/web-push@3.6.4:
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+    dependencies:
+      '@types/node': 22.15.3
+    dev: true
+
   /@typescript-eslint/eslint-plugin@8.33.0(@typescript-eslint/parser@8.33.0)(eslint@9.28.0)(typescript@5.8.2):
     resolution: {integrity: sha512-CACyQuqSHt7ma3Ns601xykeBK/rDeZa3w6IS6UtMQbixO5DWy+8TilKkviGDH6jtWCo8FGRKEK5cLLkPvEammQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3902,6 +3914,11 @@ packages:
       regex-parser: 2.3.1
     dev: true
 
+  /agent-base@7.1.3:
+    resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
+    engines: {node: '>= 14'}
+    dev: false
+
   /ajv-formats@2.1.1(ajv@8.17.1):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -4104,6 +4121,15 @@ packages:
       minimalistic-assert: 1.0.1
     dev: true
 
+  /asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+    dependencies:
+      bn.js: 4.12.2
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+    dev: false
+
   /assert@2.1.0:
     resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
     dependencies:
@@ -4240,7 +4266,6 @@ packages:
 
   /bn.js@4.12.2:
     resolution: {integrity: sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==}
-    dev: true
 
   /bn.js@5.2.2:
     resolution: {integrity: sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==}
@@ -4349,6 +4374,10 @@ packages:
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.0)
     dev: true
+
+  /buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+    dev: false
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -4963,6 +4992,12 @@ packages:
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
+
+  /ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
 
   /electron-to-chromium@1.5.110:
     resolution: {integrity: sha512-/p/OvOm6AfLtQteAHTUWwf+Vhh76PlluagzQlSnxMoOJ4R6SmAScWBrVev6rExJoUhP9zudN9+lBxoYUEmC1HQ==}
@@ -5981,9 +6016,24 @@ packages:
       entities: 2.2.0
     dev: true
 
+  /http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+    dev: false
+
   /https-browserify@1.0.0:
     resolution: {integrity: sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==}
     dev: true
+
+  /https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /icss-utils@5.1.0(postcss@8.5.3):
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
@@ -6039,7 +6089,6 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
 
   /internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -6425,6 +6474,21 @@ packages:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+    dev: false
+
+  /jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+    dev: false
+
+  /jws@4.0.0:
+    resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
     dev: false
 
   /keyv@4.5.4:
@@ -6830,7 +6894,6 @@ packages:
 
   /minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
-    dev: true
 
   /minimalistic-crypto-utils@1.0.1:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
@@ -7924,7 +7987,6 @@ packages:
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-    dev: true
 
   /safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -7941,6 +8003,10 @@ packages:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  /safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: false
 
   /sass-loader@14.2.1(webpack@5.99.9):
     resolution: {integrity: sha512-G0VcnMYU18a4N7VoNDegg2OuMjYtxnqzQWARVWCIVSZwJeiL9kg8QMsuIZOplsJgTzZLF6jGxI3AClj8I9nRdQ==}
@@ -9010,6 +9076,20 @@ packages:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
     dev: true
+
+  /web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.0
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /webpack-dev-middleware@6.1.3(webpack@5.99.9):
     resolution: {integrity: sha512-A4ChP0Qj8oGociTs6UdlRUGANIGrCDL3y+pmQMc+dSsraXHCatFpmMey4mYELA+juqwUqwQsUgJJISXl1KWmiw==}

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
-  "globalEnv": ["NODE_ENV", "DATABASE_URL"],
+  "globalEnv": ["NODE_ENV", "DATABASE_URL", "NEXT_PUBLIC_VAPID_PUBLIC_KEY", "VAPID_PRIVATE_KEY"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
closes #18 
## 📋 작업 내용

1단계: 환경 설정

- package.json - web-push 의존성 추가
- .gitignore - .env.local 제외 (VAPID 키 보안)

2단계: PWA 기본 구조

- icon.tsx - 동적 크기별 앱 아이콘 생성 (32px/192px/512px)
- apple-icon.tsx - iOS 홈화면용 아이콘 생성 (180px)
- manifest.ts - PWA 설치 안내서 (아이콘, 테마, 디스플레이 모드)
- sw.js - 푸시 알림 수신 및 표시 + 에러 처리

3단계: 서버 로직

- push-notification.ts - 푸시 알림 서버 액션 (구독/해제/전송)

4단계: 클라이언트 컴포넌트

- client-layout.tsx - React Query 등 클라이언트 Provider 래퍼
- pwa-test.tsx - PWA 기능 테스트용 UI 컴포넌트

5단계: 페이지 연결

- layout.tsx - PWA 메타데이터 추가 (manifest, viewport 등)
- page.tsx - 테스트 컴포넌트 불러오기만

6단계: 빌드 설정

- next.config.ts - 모노레포 설정 또는 PWA 관련 설정 추가
- turbo.json - 모노레포 빌드 캐시 설정

✅ .env.local 파일은 오픈채팅방에 있습니다.

✅ PWA 푸시 알림을 테스트 가이드
1. 환경변수(.env.local) 파일 `apps/web/`에 위치
2. 루트 디렉토리에서 `pnpm install`
3. 개발서버 실행 (2가지 방법)

```bash
# 루트 디렉토리에서 
# http:localhost:3000
pnpm dev

# apps/web 에서
# Next.js 15 실험적 HTTPS
# https:localhost:3002
pnpm dev --experimental-https --port 3002
```

## 🔧 변경 사항

- [ ] 📃 README.md
- [x] 📦 package.json
- [ ] 🔥 파일 삭제
- [x] 🧹 그 외 ex) .gitignore 등

## 📸 스크린샷 (선택 사항)

<img height="450" alt="스크린샷 2025-06-19 오전 4 36 30" src="https://github.com/user-attachments/assets/ef94819c-679e-4009-a40f-c74cc9307a2f" />
<img height="450" alt="스크린샷 2025-06-19 오전 4 36 30" src="https://github.com/user-attachments/assets/0cdad135-703c-4f40-8f8f-bfa428112f98" />
<img width="100%" alt="스크린샷 2025-06-19 오전 4 36 30" src="https://github.com/user-attachments/assets/849cae7d-c424-4a88-9d42-a86f8cca9ace" />

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
