### PR TITLE
[fix] shadcn 의존성 이슈 해결 (#48)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,12 +22,18 @@
     "@tailwindcss/cli": "^4.1.5",
     "@types/react": "^19.1.0",
     "eslint": "^9.28.0",
-    "tailwindcss": "^4.1.5",
+    "tailwindcss": "^4.1.10",
     "typescript": "5.8.2"
   },
   "dependencies": {
+    "autoprefixer": "^10.4.20",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "next": "^15.3.3",
+    "postcss": "^8.5.3",
     "react-dom": "^19.1.0",
-    "tailwind-variants": "^1.0.0"
+    "tailwind-merge": "^3.3.1",
+    "tailwind-variants": "^1.0.0",
+    "tw-animate-css": "^1.3.4"
   }
 }

--- a/packages/ui/src/components/ui/input.tsx
+++ b/packages/ui/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input shadow-xs flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base outline-none transition-[color,box-shadow] file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/components/*": ["src/components/*"]
+      "@/lib/*": ["src/lib/*"],
+      "@/components/*": ["src/components/*"],
+      "@/hooks/*": ["src/hooks/*"]
     },
     "outDir": "dist"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,18 +283,42 @@ importers:
 
   packages/ui:
     dependencies:
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.4.21(postcss@8.5.6)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.516.0
+        version: 0.516.0(react@19.1.0)
       next:
         specifier: ^15.3.3
         version: 15.3.4(@babel/core@7.27.4)(react-dom@19.1.0)(react@19.1.0)
+      postcss:
+        specifier: ^8.5.3
+        version: 8.5.6
       react:
         specifier: ^19
         version: 19.1.0
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      react-icons:
+        specifier: ^5.5.0
+        version: 5.5.0(react@19.1.0)
+      tailwind-merge:
+        specifier: ^3.3.1
+        version: 3.3.1
       tailwind-variants:
         specifier: ^1.0.0
         version: 1.0.0(tailwindcss@4.1.10)
+      tw-animate-css:
+        specifier: ^1.3.4
+        version: 1.3.4
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -315,7 +339,7 @@ importers:
         specifier: ^9.28.0
         version: 9.29.0
       tailwindcss:
-        specifier: ^4.1.5
+        specifier: ^4.1.10
         version: 4.1.10
       typescript:
         specifier: 5.8.2
@@ -4425,7 +4449,6 @@ packages:
       picocolors: 1.1.1
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
-    dev: true
 
   /available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -5969,7 +5992,6 @@ packages:
 
   /fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
-    dev: true
 
   /fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -7310,7 +7332,6 @@ packages:
   /normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -7703,7 +7724,6 @@ packages:
 
   /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-    dev: true
 
   /postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -7720,7 +7740,6 @@ packages:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-    dev: true
 
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -7930,6 +7949,14 @@ packages:
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  /react-icons@5.5.0(react@19.1.0):
+    resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
+    peerDependencies:
+      react: '*'
+    dependencies:
+      react: 19.1.0
+    dev: false
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -8966,7 +8993,6 @@ packages:
 
   /tw-animate-css@1.3.4:
     resolution: {integrity: sha512-dd1Ht6/YQHcNbq0znIT6dG8uhO7Ce+VIIhZUhjsryXsMPJQz3bZg7Q2eNzLwipb25bRZslGb2myio5mScd1TFg==}
-    dev: true
 
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
- #48 

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

UI 패키지에서 누락된 종속성을 해결하고 스타일링 도구 버전을 업그레이드하고, TypeScript 경로를 확장하고, 공통 유틸리티 및 재사용 가능한 입력 컴포넌트를 추가합니다.

새로운 기능:
- UI 라이브러리에 재사용 가능한 Input 컴포넌트를 추가합니다.
- 클래스 이름을 병합하기 위한 `cn` 유틸리티 함수를 도입합니다.

버그 수정:
- `class-variance-authority`, `clsx`, `tailwind-merge`, `tw-animate-css`, `autoprefixer`, `postcss` 등을 추가하여 누락된 UI 종속성을 수정합니다.

개선 사항:
- `tailwindcss`를 4.1.10으로 업그레이드하고 PostCSS 및 Autoprefixer 버전을 업데이트합니다.
- `tsconfig` 별칭을 확장하여 `lib` 및 `hooks` 디렉토리를 포함합니다.

빌드:
- 새롭고 업데이트된 종속성을 반영하기 위해 `pnpm` lockfile을 다시 생성합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve missing dependencies and upgrade styling tool versions in the UI package, extend TypeScript paths, and add common utilities and a reusable input component.

New Features:
- Add a reusable Input component to the UI library.
- Introduce a cn utility function for merging class names.

Bug Fixes:
- Fix missing UI dependencies by adding class-variance-authority, clsx, tailwind-merge, tw-animate-css, autoprefixer, postcss, and others.

Enhancements:
- Upgrade tailwindcss to 4.1.10 and update PostCSS and Autoprefixer versions.
- Extend tsconfig aliases to include lib and hooks directories.

Build:
- Regenerate pnpm lockfile to reflect new and updated dependencies.

</details>