### PR TITLE
feat: Badge 컴포넌트 구현 #23

### DIFF
--- a/apps/web/src/components/common/badge.tsx
+++ b/apps/web/src/components/common/badge.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center justify-center rounded-md px-2 py-0.5 text-xs font-medium w-fit gap-1',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-primary text-white',
+        tertiary: 'bg-rose-500 text-white',
+        outline: 'bg-transparent border border-neutral-200 text-neutral-500',
+        closed: 'bg-neutral-200 text-neutral-600',
+        success: 'bg-success-500 text-white',
+        danger: 'bg-danger-500 text-white',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+    },
+  }
+);
+
+export const Badge = ({
+  className,
+  variant = 'primary',
+  asChild = false,
+  ...props
+}: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) => {
+  const Comp = asChild ? Slot : 'span';
+  return (
+    <Comp data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
- badge.tsx 파일만 커밋
- variant prop으로 상태별 스타일 구성
- closes #23 

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

새로운 기능:
- 여러 스타일 변형과 선택적인 asChild 렌더링을 지원하는 Badge 컴포넌트 추가

<details>
<summary>Original summary in English</summary>

## Sourcery 요약

재사용 가능한 Badge 컴포넌트를 추가하고, 사용자 정의 가능한 variant와 선택적인 child 렌더링 유연성을 제공합니다.

새로운 기능:
- 여러 스타일 variant를 지원하는 variant prop을 가진 Badge 컴포넌트 추가

개선 사항:
- Radix Slot을 통해 선택적인 asChild 렌더링을 지원하고 사용자 정의 className을 병합합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a reusable Badge component with customizable variants and optional child rendering flexibility

New Features:
- Add Badge component with variant prop supporting multiple style variants

Enhancements:
- Support optional asChild rendering via Radix Slot and merge custom className

</details>

</details>