### PR TITLE
[feat] 네비게이션과 메인 페이지들 연결

### DIFF
--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import ChatPage from '@/pages/ChatPage';
+
+const Page = () => {
+  return <ChatPage />;
+};
+
+export default Page;

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import ProfilePage from '@/pages/ProfilePage';
+
+const Page = () => {
+  return <ProfilePage />;
+};
+
+export default Page;

--- a/apps/web/app/search/page.tsx
+++ b/apps/web/app/search/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import SearchPage from '@/pages/SearchPage';
+
+const Page = () => {
+  return <SearchPage />;
+};
+
+export default Page;

--- a/apps/web/src/components/layout/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation.tsx
@@ -5,12 +5,14 @@ import { usePathname } from 'next/navigation';
 
 import { HouseIcon, MessagesSquare, SearchIcon, UserRoundIcon } from 'lucide-react';
 
+import { ROUTES, type NavMenuItem } from '@/constants/routes';
+
 // route 작업 후 수정 필요
-const NAV_MENU = [
-  { name: '홈', href: '/', icon: HouseIcon },
-  { name: '검색', href: '/search', icon: SearchIcon },
-  { name: '채팅', href: '/chat', icon: MessagesSquare },
-  { name: '프로필', href: '/profile', icon: UserRoundIcon },
+const NAV_MENU: NavMenuItem[] = [
+  { name: '홈', href: ROUTES.HOME, icon: HouseIcon },
+  { name: '검색', href: ROUTES.SEARCH, icon: SearchIcon },
+  { name: '채팅', href: ROUTES.CHAT, icon: MessagesSquare },
+  { name: '프로필', href: ROUTES.PROFILE, icon: UserRoundIcon },
 ];
 
 const Navigation = () => {

--- a/apps/web/src/constants/routes.ts
+++ b/apps/web/src/constants/routes.ts
@@ -1,0 +1,24 @@
+export const ROUTES = {
+  // 메인 하단 탭
+  HOME: '/',
+  SEARCH: '/search',
+  CHAT: '/chat',
+  PROFILE: '/profile',
+
+  // 경매 관련
+  AUCTION_DETAIL: '/auction',
+
+  // 인증 관련
+  LOGIN: '/auth/login',
+  SIGNUP: '/auth/signup',
+
+  // 기타 페이지
+} as const;
+
+export type NavMenuItem = {
+  name: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+};
+
+export type RouteValues = (typeof ROUTES)[keyof typeof ROUTES];

--- a/apps/web/src/pages/ChatPage.tsx
+++ b/apps/web/src/pages/ChatPage.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+const ChatPage = () => {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <h1 className="text-2xl font-bold">채팅 페이지</h1>
+    </div>
+  );
+};
+
+export default ChatPage;

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -2,8 +2,8 @@
 
 const HomePage = () => {
   return (
-    <div>
-      <h1>메인 홈 페이지</h1>
+    <div className="flex h-full w-full items-center justify-center">
+      <h1 className="text-2xl font-bold">메인 홈 페이지</h1>
     </div>
   );
 };

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+const ProfilePage = () => {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <h1 className="text-2xl font-bold">프로필 페이지</h1>
+    </div>
+  );
+};
+
+export default ProfilePage;

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+const SearchPage = () => {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <h1 className="text-2xl font-bold">검색 페이지</h1>
+    </div>
+  );
+};
+
+export default SearchPage;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
closes #52 
## 📋 작업 내용

- 라우트 상수 파일 생성
- 네비게이션 컴포넌트에 라우트 상수 적용
- 각 메인 페이지 생성 및 연결

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

https://github.com/user-attachments/assets/2773e079-9f84-43fb-8b2b-9353054327ab


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

중앙 집중식 경로 정의를 도입하고, 새로운 상수를 사용하도록 탐색을 리팩터링하며, 주요 홈, 검색, 채팅, 프로필 페이지를 기본적인 자리 표시자 UI와 연결합니다.

새로운 기능:
- 중앙 경로 상수 및 NavMenuItem/RouteValues 타입 생성
- 기본적인 중앙 집중식 자리 표시자가 있는 채팅, 프로필, 검색 페이지 컴포넌트 추가
- 새로운 메인 페이지 컴포넌트를 렌더링하도록 Next.js 앱 라우터 페이지 구성

개선 사항:
- 하드 코딩된 경로 대신 ROUTES 상수를 사용하도록 탐색 메뉴 리팩터링
- 중앙 집중식 컨테이너 및 스타일이 지정된 제목으로 홈페이지 레이아웃 업데이트

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce centralized route definitions, refactor navigation to use the new constants, and connect the main Home, Search, Chat, and Profile pages with basic placeholder UIs.

New Features:
- Create central route constants and NavMenuItem/RouteValues types
- Add Chat, Profile, and Search page components with basic centered placeholders
- Configure Next.js app router pages to render the new main page components

Enhancements:
- Refactor navigation menu to use ROUTES constants instead of hard-coded paths
- Update HomePage layout with centered container and styled heading

</details>