### PR TITLE
[fix] prisma 자동화 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "with-tailwind",
   "private": true,
   "scripts": {
-    "build": "turbo run build",
-    "dev": "turbo run dev",
+    "build": "pnpm --filter @repo/db db:generate && turbo run build",
+    "dev": "pnpm --filter @repo/db db:generate && turbo run dev",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",
     "check-types": "turbo run check-types",
     "format": "prettier --write \"**/*.{ts,tsx,md,json,yml,yaml}\"",
-    "prepare": "lefthook install"
+    "prepare": "lefthook install",
+    "db:generate": "pnpm --filter @repo/db db:generate"
   },
   "devDependencies": {
     "lefthook": "^1.11.13",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,7 +12,8 @@
     "db:push": "dotenv -e ../../.env -- prisma db push",
     "db:deploy": "dotenv -e ../../.env -- prisma migrate deploy",
     "db:migrate": "dotenv -e ../../.env -- prisma migrate dev",
-    "db:studio": "dotenv -e ../../.env -- prisma studio"
+    "db:studio": "dotenv -e ../../.env -- prisma studio",
+    "postinstall": "dotenv -e ../../.env -- prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^6.9.0"

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
   "globalEnv": ["NODE_ENV", "DATABASE_URL", "NEXT_PUBLIC_VAPID_PUBLIC_KEY", "VAPID_PRIVATE_KEY"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "@repo/db#db:generate"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
       "env": ["DATABASE_URL", "DIRECT_URL", "NODE_ENV"]
@@ -18,12 +18,14 @@
       "dependsOn": ["^check-types"]
     },
     "dev": {
+      "dependsOn": ["@repo/db#db:generate"],
       "cache": false,
       "persistent": true,
       "env": ["NODE_ENV", "DATABASE_URL", "DIRECT_URL"]
     },
     "db:generate": {
       "cache": false,
+      "inputs": ["prisma/schema.prisma", ".env*"],
       "env": ["NODE_ENV", "DATABASE_URL"]
     },
     "db:push": {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
closes #84 
## 📋 작업 내용

- postinstall 추가
    - 별도 명령어 없이 pnpm install만 해도 Prisma Client가 자동으로 생성되도록 수정
- 루트 디렉토리의 package.json 파일 수정

    - pnpm dev 실행 시 → 먼저 @repo/db 패키지의 db:generate 실행 → 그 다음 turbo run dev 실행
    - pnpm build 실행 시 → 먼저 @repo/db 패키지의 db:generate 실행 → 그 다음 turbo run build 실행
    - Prisma 스키마나 env 파일이 변경되면 db:generate가 다시 실행됨

## 🔧 변경 사항

- [ ] 📃 README.md
- [x] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

# ✅ 최신상태 동기화 후, pnpm install -> pnpm dev 해주세요 

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

실제 동작 시나리오:
시나리오 1: 일반적인 코드 업데이트
```bash
git fetch upstream
git merge upstream/main
# → dependencies 변경 없음
# → pnpm install 불필요
# → postinstall 실행 안됨
# → 하지만 pnpm dev 실행 시 turbo가 자동으로 db:generate 실행! ✅
```
시나리오 2: 새 패키지가 추가된 경우
```bash
git fetch upstream  
git merge upstream/main
# → package.json 변경됨
pnpm install  # → 필요함
# → postinstall 자동 실행됨 ✅
```
