### PR TITLE
[feat] menu list 제작 #74

### DIFF
--- a/apps/web/src/components/common/menu-list.tsx
+++ b/apps/web/src/components/common/menu-list.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import Link from 'next/link';
+
+interface MenuItem {
+  title: string;
+  route: string;
+}
+
+interface MenuSection {
+  title: string;
+  items: MenuItem[];
+}
+
+const menuSections: MenuSection[] = [
+  {
+    title: '계정 정보',
+    items: [
+      { title: '판매 내역', route: '/profile/sales' },
+      { title: '구매 내역', route: '/profile/purchases' },
+      { title: '관심 목록', route: '/profile/wishlist' },
+      { title: '위치 정보 설정', route: '/profile/location' },
+      { title: '결제 정보 설정', route: '/profile/payment' },
+    ],
+  },
+  {
+    title: '고객 지원',
+    items: [
+      { title: '고객센터', route: '/support' },
+      { title: '설정', route: '/settings' },
+    ],
+  },
+];
+
+export const MenuList = () => {
+  return (
+    <div className="space-y-14">
+      {menuSections.map((section) => (
+        <div key={section.title} className="w-full px-6">
+          <div className="mb-6 font-['Noto_Sans_KR'] text-lg font-bold text-neutral-900">
+            {section.title}
+          </div>
+          <div className="space-y-6">
+            {section.items.map((item) => (
+              <Link
+                key={item.title}
+                href={item.route}
+                className="block font-['Noto_Sans_KR'] text-sm font-medium leading-[24px] text-neutral-900"
+              >
+                {item.title}
+              </Link>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/apps/web/src/components/common/menu-list.tsx
+++ b/apps/web/src/components/common/menu-list.tsx
@@ -8,12 +8,14 @@ interface MenuItem {
 }
 
 interface MenuSection {
+  id: string; // 고유 ID 추가!
   title: string;
   items: MenuItem[];
 }
 
 const menuSections: MenuSection[] = [
   {
+    id: 'account', // 고유 ID
     title: '계정 정보',
     items: [
       { title: '판매 내역', route: '/profile/sales' },
@@ -24,6 +26,7 @@ const menuSections: MenuSection[] = [
     ],
   },
   {
+    id: 'support',
     title: '고객 지원',
     items: [
       { title: '고객센터', route: '/support' },
@@ -34,25 +37,24 @@ const menuSections: MenuSection[] = [
 
 export const MenuList = () => {
   return (
-    <div className="space-y-14">
+    <nav aria-label="마이페이지 메뉴 목록">
       {menuSections.map((section) => (
-        <div key={section.title} className="w-full px-6">
-          <div className="mb-6 font-['Noto_Sans_KR'] text-lg font-bold text-neutral-900">
-            {section.title}
-          </div>
-          <div className="space-y-6">
+        <section key={section.id} className="mb-14 w-full space-y-6 px-6">
+          <h2 className="mb-6 text-lg font-bold text-neutral-900">{section.title}</h2>
+          <ul className="space-y-6">
             {section.items.map((item) => (
-              <Link
-                key={item.title}
-                href={item.route}
-                className="block font-['Noto_Sans_KR'] text-sm font-medium leading-[24px] text-neutral-900"
-              >
-                {item.title}
-              </Link>
+              <li key={item.route}>
+                <Link
+                  href={item.route}
+                  className="block text-sm font-medium leading-[24px] text-neutral-900"
+                >
+                  {item.title}
+                </Link>
+              </li>
             ))}
-          </div>
-        </div>
+          </ul>
+        </section>
       ))}
-    </div>
+    </nav>
   );
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- [feat] menu-list #74 

## 🔧 변경 사항

- 컴포넌트 제작 후 구조 개선

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![Screenshot 2025-06-25 at 00 34 21](https://github.com/user-attachments/assets/5c53bc40-e42b-44c0-99be-cc98a5f542de)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

계정 및 지원 페이지를 위한 구조화된 탐색 섹션을 렌더링하는 재사용 가능한 MenuList 컴포넌트를 도입합니다.

새로운 기능:
- 하드 코딩된 계정 및 지원 메뉴 섹션과 링크를 포함한 MenuList 컴포넌트 추가

개선 사항:
- MenuItem 및 MenuSection 인터페이스를 정의하고 고유한 섹션 ID를 포함합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a reusable MenuList component to render structured navigation sections for account and support pages

New Features:
- Add MenuList component with hardcoded account and support menu sections and links

Enhancements:
- Define MenuItem and MenuSection interfaces and include unique section IDs

</details>