### PR TITLE
[chore] AuctionPrice Schema 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,6 @@ output/
 # IDE settings
 .idea/
 
-# Prisma generated files
+# Prisma
+packages/db/prisma/migrations/migration_lock.toml
 packages/db/src/generated/

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,6 +13,7 @@
     "db:deploy": "dotenv -e ../../.env -- prisma migrate deploy",
     "db:migrate": "dotenv -e ../../.env -- prisma migrate dev",
     "db:studio": "dotenv -e ../../.env -- prisma studio",
+    "db:reset": "dotenv -e ../../.env -- prisma migrate reset --force",
     "postinstall": "dotenv -e ../../.env -- prisma generate"
   },
   "dependencies": {

--- a/packages/db/prisma/migrations/20250626104937_add_instant_buy_enabled/migration.sql
+++ b/packages/db/prisma/migrations/20250626104937_add_instant_buy_enabled/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Added the required column `min_bid_price` to the `auction_prices` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "auction_prices" ADD COLUMN     "is_instant_buy_enabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "min_bid_price" INTEGER NOT NULL;

--- a/packages/db/prisma/migrations/20250626105544_remove_min_bid_price/migration.sql
+++ b/packages/db/prisma/migrations/20250626105544_remove_min_bid_price/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `min_bid_price` on the `auction_prices` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "auction_prices" DROP COLUMN "min_bid_price";

--- a/packages/db/prisma/migrations/20250626130325_add_extended_auction_field/migration.sql
+++ b/packages/db/prisma/migrations/20250626130325_add_extended_auction_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "auction_prices" ADD COLUMN     "is_extended_auction" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -119,9 +119,14 @@ model AuctionPrice {
   id           String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   itemId       String @unique @map("item_id") @db.Uuid
   startPrice   Int    @map("start_price")
-  instantPrice Int?   @map("instant_price")
+  instantPrice Int?   @map("instant_price") // 즉시 구매 가격
   minBidUnit   Int    @map("min_bid_unit")
   currentPrice Int    @map("current_price")
+
+  // 즉시 구매 여부
+  isInstantBuyEnabled Boolean @default(false) @map("is_instant_buy_enabled")
+  // 연장경매 여부 (새로 추가)
+  isExtendedAuction   Boolean @default(false) @map("is_extended_auction")
 
   // Relations
   item AuctionItem @relation(fields: [itemId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
closes #126 
## 📋 작업 내용

- AuctionPrice 테이블에 isInstantBuyEnabled (즉시구매 여부), isExtendedAuction (연장경매 여부) 추가
- .gitignore에 prisma/migrations/migration_lock.toml 추가
- package.json에 db:reset 스크립트 추가

## 🔧 변경 사항

- [ ] 📃 README.md
- [x] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

# pnpm install 해주세요

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
