### PR TITLE
feat: 등록한 경매 내역 페이지 퍼플리싱 #142

### DIFF
--- a/apps/web/app/profile/sales/page.tsx
+++ b/apps/web/app/profile/sales/page.tsx
@@ -1,0 +1,7 @@
+import TradeListPage from '@/pages/profile/TradePage';
+
+const Page = () => {
+  return <TradeListPage />;
+};
+
+export default Page;

--- a/apps/web/src/components/categories/categories.tsx
+++ b/apps/web/src/components/categories/categories.tsx
@@ -1,50 +1,23 @@
 import React from 'react';
 
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs-categories';
+import { TabItem } from '@/lib/constants/tabs';
 
 interface CategoriesProps {
-  id: string;
-  name: string;
+  items: TabItem[];
 }
 
-const CATEGORIES: CategoriesProps[] = [
-  {
-    id: '1',
-    name: 'NOW 🔥',
-  },
-  {
-    id: '2',
-    name: '가전제품',
-  },
-  {
-    id: '3',
-    name: '생활용품',
-  },
-  {
-    id: '4',
-    name: '가구',
-  },
-  {
-    id: '5',
-    name: '뷰티/미용',
-  },
-  {
-    id: '6',
-    name: '교환권/쿠폰',
-  },
-  {
-    id: '7',
-    name: '유아동',
-  },
-];
+const Categories = ({ items }: CategoriesProps) => {
+  if (!items || items.length === 0) {
+    return <div>카테고리가 없습니다.</div>;
+  }
 
-const Categories = () => {
   return (
-    <Tabs defaultValue={CATEGORIES[0]!.id}>
+    <Tabs defaultValue={items[0]!.id}>
       <TabsList className="my-3">
-        {CATEGORIES.map(({ id, name }) => {
+        {items.map(({ id, name }) => {
           return (
-            <TabsTrigger value={id} key={name}>
+            <TabsTrigger key={id} value={id}>
               {name}
             </TabsTrigger>
           );

--- a/apps/web/src/lib/constants/tabs.ts
+++ b/apps/web/src/lib/constants/tabs.ts
@@ -1,0 +1,31 @@
+export interface TabItem {
+  id: string;
+  name: string;
+}
+
+export const CATEGORIES: TabItem[] = [
+  {
+    id: '1',
+    name: 'NOW 🔥',
+  },
+  {
+    id: '2',
+    name: '가전제품',
+  },
+  {
+    id: '3',
+    name: '생활용품',
+  },
+  {
+    id: '4',
+    name: '가구',
+  },
+  {
+    id: '5',
+    name: '생활용품',
+  },
+  {
+    id: '6',
+    name: '가구',
+  },
+];

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -2,11 +2,12 @@
 
 import Categories from '@/components/categories/categories';
 import AuctionItemList from '@/components/common/auction-item-List';
+import { CATEGORIES } from '../lib/constants/tabs';
 
 const HomePage = () => {
   return (
     <section>
-      <Categories />
+      <Categories items={CATEGORIES} />
       <AuctionItemList />
     </section>
   );

--- a/apps/web/src/pages/profile/TradePage.tsx
+++ b/apps/web/src/pages/profile/TradePage.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import React from 'react';
+
+import AuctionItemList from '@/components/common/auction-item-List';
+import Categories from '@/components/categories/categories';
+import { CATEGORIES } from '@/lib/constants/tabs';
+
+const TradeListPage = () => {
+  console.log(CATEGORIES);
+
+  return (
+    <div>
+      {/* 상단 헤더 */}
+      {/* <div className="absolute left-0 top-0 z-10 w-full">
+        <Header title="판매 내역" />
+      </div> */}
+
+      <Categories items={CATEGORIES} />
+      <AuctionItemList />
+    </div>
+  );
+};
+
+export default TradeListPage;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

feat: 등록한 경매 내역 페이지 퍼플리싱 #142 

## 📋 작업 내용

- category 컴포넌트 수정
- 판매내역 페이지 퍼블리싱

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![스크린샷 2025-06-28 165832](https://github.com/user-attachments/assets/7cb480cc-46e0-489f-82c6-8fe12e341db5)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

판매 내역 페이지를 구현하고 카테고리 탭이 공유 상수 및 동적 props를 사용하도록 리팩터링합니다.

새로운 기능:
- 프로필 아래에 등록된 경매를 표시하는 판매 내역 페이지를 추가합니다.

개선 사항:
- Categories 컴포넌트가 동적 TabItem 목록을 허용하고 빈 상태를 처리하도록 리팩터링합니다.
- 카테고리 탭 아이템을 공유 상수 파일로 추출합니다.
- HomePage가 공유된 `CATEGORIES`를 Categories 컴포넌트에 전달하도록 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a sales history page and refactor category tabs to use shared constants and dynamic props

New Features:
- Add a sales history page under profile to display registered auctions

Enhancements:
- Refactor Categories component to accept a dynamic list of TabItem and handle empty state
- Extract category tab items into a shared constants file
- Update HomePage to pass the shared CATEGORIES to the Categories component

</details>