### PR TITLE
[fix] 분리된 타입 파일 정리 및 홈 헤더의 셀렉트 박스 수정, 상세페이지 Routes 경로수정

### DIFF
--- a/apps/web/app/api/auctions/[id]/route.ts
+++ b/apps/web/app/api/auctions/[id]/route.ts
@@ -1,4 +1,4 @@
-import { AuctionDetailResponse } from '@/lib/types/auction';
+import { AuctionDetailResponse } from '@/lib/types/auction-prisma';
 import { prisma } from '@repo/db';
 import { NextRequest, NextResponse } from 'next/server';
 

--- a/apps/web/src/components/layout/dynamic-header.tsx
+++ b/apps/web/src/components/layout/dynamic-header.tsx
@@ -2,8 +2,6 @@ import { usePathname, useRouter } from 'next/navigation';
 
 import { BellRing, ChevronLeft, EllipsisVertical } from 'lucide-react';
 
-import { useSortStore } from '@/lib/zustand/store/sort-store';
-
 import Header from './header';
 import HomeSelectBox from './home-selectbox';
 
@@ -24,10 +22,17 @@ const DynamicHeader = () => {
   // 메인 홈 페이지(경매리스트) - (좌)셀렉트박스 + (우)알림
   if (pathname === '/') {
     // Zustand 스토어에서 정렬 함수 가져오기
-    const setSortOption = useSortStore((state) => state.setSortOption);
+    // const setSortOption = useSortStore((state) => state.setSortOption);
     return (
       <Header
-        leftContent={<HomeSelectBox onSortChange={setSortOption} />}
+        leftContent={
+          <HomeSelectBox
+            onSortChange={(sortOption) => {
+              // Zustand 스토어에 정렬 옵션 저장
+              // setSortOption(sortOption);
+            }}
+          />
+        }
         rightIcon={BellRing}
         onRightClick={() => {
           // 알림 페이지로 이동

--- a/apps/web/src/components/layout/home-selectbox.tsx
+++ b/apps/web/src/components/layout/home-selectbox.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { SortOption } from '@/lib/types/auction';
+import { SortOption } from '@/lib/types/auction-prisma';
 
 import { SelectBox } from '../common/select-box';
 
@@ -12,12 +12,14 @@ const HomeSelectBox = ({ onSortChange }: HomeSelectBoxProps) => {
   const [selectedSort, setSelectedSort] = useState<SortOption>('latest');
 
   const sortOptions = [
-    { value: 'latest', label: '최신순' },
-    { value: 'ending_soon', label: '마감임박순' },
-    { value: 'price_low', label: '낮은가격순' },
-    { value: 'price_high', label: '높은가격순' },
-    { value: 'popular', label: '인기순' },
-    { value: 'title_asc', label: '제목순' },
+    // { value: 'latest', label: '최신순' },
+    // { value: 'ending_soon', label: '마감임박순' },
+    // { value: 'price_low', label: '낮은가격순' },
+    // { value: 'price_high', label: '높은가격순' },
+    // { value: 'popular', label: '인기순' },
+    // { value: 'title_asc', label: '제목순' },
+    { value: 'yeoksamdong', label: '역삼동' },
+    { value: 'setting-neighborhood', label: '동네 설정하기' },
   ];
 
   const handleSortChange = (value: string) => {

--- a/apps/web/src/lib/types/auction-prisma.ts
+++ b/apps/web/src/lib/types/auction-prisma.ts
@@ -20,6 +20,12 @@ export type AuctionListItem = Prisma.AuctionItemGetPayload<{
         isExtendedAuction: true; // 연장 경매 여부
       };
     };
+    auctionImages: {
+      select: {
+        id: true; // 이미지 ID
+        urls: true; // 이미지 URL 배열
+      };
+    };
     _count: {
       select: {
         bids: true;
@@ -29,10 +35,73 @@ export type AuctionListItem = Prisma.AuctionItemGetPayload<{
   };
 }>;
 
+// 경매 상세 페이지
+export type AuctionDetailItem = Prisma.AuctionItemGetPayload<{
+  include: {
+    // 판매자
+    seller: {
+      select: {
+        id: true;
+        nickname: true;
+        profileImg: true;
+        isVerified: true;
+      };
+    };
+    // 카테고리
+    category: {
+      select: {
+        id: true;
+        name: true;
+      };
+    };
+    // 가격
+    auctionPrice: {
+      select: {
+        startPrice: true;
+        currentPrice: true;
+        instantPrice: true;
+        minBidUnit: true;
+        isInstantBuyEnabled: true;
+        isExtendedAuction: true;
+      };
+    };
+    auctionImages: {
+      select: {
+        id: true; // 이미지 ID
+        urls: true; // 이미지 URL 배열
+      };
+    };
+    // 통계
+    _count: {
+      select: {
+        bids: true;
+        favoriteItems: true;
+      };
+    };
+  };
+}>;
+// 찜하기 여부
+export interface UserFavoriteStatus {
+  isFavorite: boolean;
+}
+
+// 이미지 배열 처리 헬퍼 함수 타입
+export interface ProcessedImages {
+  allImages: string[]; // 모든 이미지 URL 배열
+  thumbnailUrl: string; // 대표 이미지 (첫 번째 이미지 또는 기본값)
+}
+
 // API 응답 타입들
+// 경매 목록 응답
 export interface AuctionListResponse {
   data: AuctionListItem[];
   total: number;
+}
+
+// 경매 상세페이지 응답
+export interface AuctionDetailResponse {
+  data: AuctionDetailItem;
+  userFavorite: UserFavoriteStatus;
 }
 
 // 필터 및 정렬 타입들

--- a/apps/web/src/lib/types/auction.ts
+++ b/apps/web/src/lib/types/auction.ts
@@ -8,116 +8,6 @@ export interface AuctionItemProps {
   thumbnailUrl: string;
 }
 
-
-export type { AuctionItemProps };
-
-import type { Prisma } from '@repo/db';
-
-// 경매 목록 아이템
-// 화면에 보여질 필드들: 카테고리, 아이템 썸네일, 타이틀, 경매상태, 시작가, 시작시간, 마감시간, 현재 가격
-export type AuctionListItem = Prisma.AuctionItemGetPayload<{
-  include: {
-    category: {
-      select: {
-        id: true;
-        name: true;
-      };
-    };
-    auctionPrice: {
-      select: {
-        startPrice: true; // 시작가 (start_price)
-        currentPrice: true; // 현재 가격 (current_price)
-        instantPrice: true; // 즉시구매가 (instant_price)
-        minBidUnit: true; // 최소 입찰 단위 (min_bid_unit)
-        isInstantBuyEnabled: true; // 즉시구매 가능 여부
-        isExtendedAuction: true; // 연장 경매 여부
-      };
-    };
-    auctionImages: {
-      select: {
-        id: true; // 이미지 ID
-        urls: true; // 이미지 URL 배열
-      };
-    };
-    _count: {
-      select: {
-        bids: true;
-        favoriteItems: true;
-      };
-    };
-  };
-}>;
-
-// 경매 상세 페이지
-export type AuctionDetailItem = Prisma.AuctionItemGetPayload<{
-  include: {
-    // 판매자
-    seller: {
-      select: {
-        id: true;
-        nickname: true;
-        profileImg: true;
-        isVerified: true;
-      };
-    };
-    // 카테고리
-    category: {
-      select: {
-        id: true;
-        name: true;
-      };
-    };
-    // 가격
-    auctionPrice: {
-      select: {
-        startPrice: true;
-        currentPrice: true;
-        instantPrice: true;
-        minBidUnit: true;
-        isInstantBuyEnabled: true;
-        isExtendedAuction: true;
-      };
-    };
-    auctionImages: {
-      select: {
-        id: true; // 이미지 ID
-        urls: true; // 이미지 URL 배열
-      };
-    };
-    // 통계
-    _count: {
-      select: {
-        bids: true;
-        favoriteItems: true;
-      };
-    };
-  };
-}>;
-// 찜하기 여부
-export interface UserFavoriteStatus {
-  isFavorite: boolean;
-}
-
-// 이미지 배열 처리 헬퍼 함수 타입
-export interface ProcessedImages {
-  allImages: string[]; // 모든 이미지 URL 배열
-  thumbnailUrl: string; // 대표 이미지 (첫 번째 이미지 또는 기본값)
-}
-
-// API 응답 타입들
-
-// 경매 리스트 전체 조회 응답
-export interface AuctionListResponse {
-  data: AuctionListItem[];
-  total: number;
-}
-
-// 경매 상세페이지 응답
-export interface AuctionDetailResponse {
-  data: AuctionDetailItem;
-  userFavorite: UserFavoriteStatus;
-}
-
 // 필터 및 정렬 타입들
 export interface AuctionPriceInput {
   start_price: number;
@@ -136,7 +26,6 @@ export interface AuctionFormData {
   auction_type?: 'normal' | 'flash';
   images: string[];
 }
-
 
 export interface Auction extends AuctionFormData {
   id: string;

--- a/apps/web/src/lib/types/index.ts
+++ b/apps/web/src/lib/types/index.ts
@@ -1,2 +1,3 @@
 // TypeScript 타입 정의들
+export * from './auction';
 export * from './users';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

경매 유형 정의를 통합하고 전용 Prisma 유형 파일로 재배치하여 정리하고, 유형 인덱스 내보내기를 간소화하고, 위치별 옵션을 사용하도록 홈 헤더 선택 상자를 업데이트하고, 동적 헤더 구성 요소에서 정렬 로직을 스텁합니다.

개선 사항:
- 더 나은 구성을 위해 경매 관련 TypeScript 인터페이스 및 페이로드 유형을 auction-prisma.ts로 통합합니다.
- 중앙 index.ts에서 통합된 경매 유형을 내보냅니다.
- HomeSelectBox의 일반 정렬 옵션을 위치별 항목으로 대체합니다.
- DynamicHeader에서 활성 정렬 로직을 제거하고 스텁된 onSortChange 콜백으로 대체합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up auction type definitions by consolidating and relocating them into a dedicated Prisma types file, streamline the types index export, update the home header select box to use location-specific options, and stub out the sorting logic in the dynamic header component.

Enhancements:
- Consolidate auction-related TypeScript interfaces and payload types into auction-prisma.ts for better organization
- Export the unified auction types from the central index.ts
- Replace generic sort options in HomeSelectBox with location-specific entries
- Remove active sorting logic in DynamicHeader and replace it with a stubbed onSortChange callback

</details>