### PR TITLE
[style] 이전 헤더로 롤백, params 비동기 처리

### DIFF
--- a/apps/web/app/api/auctions/[id]/route.ts
+++ b/apps/web/app/api/auctions/[id]/route.ts
@@ -7,7 +7,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   try {
     const { searchParams } = new URL(request.url);
     const userId = searchParams.get('userId'); // 사용자 ID (찜한 상태 확인용)
-    const auctionId = params.id;
+    const auctionId = (await params).id;
 
     // 경매아이템 상세 정보조회
     const auctionItem = await prisma.auctionItem.findUnique({

--- a/apps/web/app/api/auctions/route.ts
+++ b/apps/web/app/api/auctions/route.ts
@@ -4,12 +4,16 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(request: NextRequest) {
   try {
+    console.log('🚀 경매 목록 API 호출');
+
     const { searchParams } = new URL(request.url);
 
     // 쿼리 파라미터 추출
     const location_id = searchParams.get('location_id');
     const category_id = searchParams.get('category_id');
     const sort = (searchParams.get('sort') as SortOption) || 'latest';
+
+    console.log('📋 파라미터:', { location_id, category_id, sort });
 
     // 필터 조건 구성
     const where: any = {
@@ -52,7 +56,6 @@ export async function GET(request: NextRequest) {
     const total = await prisma.auctionItem.count({ where });
 
     // 경매 목록 조회 (전체)
-    // 화면에 보여질 필드들: 카테고리, 아이템 썸네일, 타이틀, 경매상태, 시작가, 시작시간, 마감시간, 현재 가격
     const auctions = await prisma.auctionItem.findMany({
       where,
       include: {
@@ -64,15 +67,14 @@ export async function GET(request: NextRequest) {
         },
         auctionPrice: {
           select: {
-            startPrice: true, // 시작가 (start_price)
-            currentPrice: true, // 현재 가격 (current_price)
-            instantPrice: true, // 즉시구매가 (instant_price)
-            minBidUnit: true, // 최소 입찰 단위 (min_bid_unit)
-            isInstantBuyEnabled: true, // 즉시구매 가능 여부 (is_instant_buy_enabled)
-            isExtendedAuction: true, // 연장 경매 여부 (is_extended_auction)
+            startPrice: true, // 시작가
+            currentPrice: true, // 현재 가격
+            instantPrice: true, // 즉시구매가
+            minBidUnit: true, // 최소 입찰 단위
+            isInstantBuyEnabled: true, // 즉시구매 가능 여부
+            isExtendedAuction: true, // 연장 경매 여부
           },
         },
-        // 이미지 관계 추가
         auctionImages: {
           select: {
             id: true,
@@ -101,13 +103,16 @@ export async function GET(request: NextRequest) {
       total,
     };
 
+    console.log(`✅ 성공: 총 ${total}개 중 ${processedAuctions.length}개 반환`);
+
     return NextResponse.json(response);
   } catch (error) {
-    console.error('Error fetching auctions:', error);
+    console.error('🚨 경매 목록 조회 에러:', error);
     return NextResponse.json(
       {
         error: 'Internal server error',
         details: error instanceof Error ? error.message : 'Unknown error',
+        message: '경매 목록을 불러오는 중 오류가 발생했습니다.',
       },
       { status: 500 }
     );

--- a/apps/web/src/components/common/auction-item-List.tsx
+++ b/apps/web/src/components/common/auction-item-List.tsx
@@ -4,10 +4,9 @@ import { useState } from 'react';
 
 import AuctionItemCard from '@/components/common/auction-item-card';
 
-import { AuctionItemProps } from '@/types/auction';
 import { useAuctions } from '@/hooks/queries/auction/useAuctions';
-import { SortOption } from '@/lib/types/auction';
-
+import { SortOption } from '@/lib/types/auction-prisma';
+import { AuctionItemProps } from '@/types/auction';
 
 interface AuctionItemListProps {
   selectedCategoryId?: string;

--- a/apps/web/src/components/layout/dynamic-header.tsx
+++ b/apps/web/src/components/layout/dynamic-header.tsx
@@ -1,6 +1,6 @@
-import { usePathname, useRouter } from 'next/navigation';
-
+import { useSortStore } from '@/lib/zustand/store/sort-store';
 import { BellRing, ChevronLeft, EllipsisVertical } from 'lucide-react';
+import { usePathname, useRouter } from 'next/navigation';
 
 import Header from './header';
 import HomeSelectBox from './home-selectbox';
@@ -22,17 +22,10 @@ const DynamicHeader = () => {
   // 메인 홈 페이지(경매리스트) - (좌)셀렉트박스 + (우)알림
   if (pathname === '/') {
     // Zustand 스토어에서 정렬 함수 가져오기
-    // const setSortOption = useSortStore((state) => state.setSortOption);
+    const setSortOption = useSortStore((state) => state.setSortOption);
     return (
       <Header
-        leftContent={
-          <HomeSelectBox
-            onSortChange={(sortOption) => {
-              // Zustand 스토어에 정렬 옵션 저장
-              // setSortOption(sortOption);
-            }}
-          />
-        }
+        leftContent={<HomeSelectBox onSortChange={setSortOption} />}
         rightIcon={BellRing}
         onRightClick={() => {
           // 알림 페이지로 이동

--- a/apps/web/src/components/layout/home-selectbox.tsx
+++ b/apps/web/src/components/layout/home-selectbox.tsx
@@ -12,14 +12,12 @@ const HomeSelectBox = ({ onSortChange }: HomeSelectBoxProps) => {
   const [selectedSort, setSelectedSort] = useState<SortOption>('latest');
 
   const sortOptions = [
-    // { value: 'latest', label: '최신순' },
-    // { value: 'ending_soon', label: '마감임박순' },
-    // { value: 'price_low', label: '낮은가격순' },
-    // { value: 'price_high', label: '높은가격순' },
-    // { value: 'popular', label: '인기순' },
-    // { value: 'title_asc', label: '제목순' },
-    { value: 'yeoksamdong', label: '역삼동' },
-    { value: 'setting-neighborhood', label: '동네 설정하기' },
+    { value: 'latest', label: '최신순' },
+    { value: 'ending_soon', label: '마감임박순' },
+    { value: 'price_low', label: '낮은가격순' },
+    { value: 'price_high', label: '높은가격순' },
+    { value: 'popular', label: '인기순' },
+    { value: 'title_asc', label: '제목순' },
   ];
 
   const handleSortChange = (value: string) => {

--- a/apps/web/src/lib/api/auction.ts
+++ b/apps/web/src/lib/api/auction.ts
@@ -1,7 +1,4 @@
-
-import { AuctionDetailResponse, AuctionListResponse } from '@/types/auction';
-
-import { AuctionListResponse } from '@/types/auction-prisma';
+import { AuctionDetailResponse, AuctionListResponse } from '@/types/auction-prisma';
 
 import apiClient from './client';
 

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -1,6 +1,6 @@
 // HTTP 클라이언트 설정 (업데이트된 버전)
 // API 요청을 처리하는 Axios 클라이언트를 설정하는 파일
-
+// apps/web/src/lib/api/client.ts
 import axios, {
   AxiosError,
   AxiosInstance,

--- a/apps/web/src/lib/types/index.ts
+++ b/apps/web/src/lib/types/index.ts
@@ -1,3 +1,2 @@
 // TypeScript 타입 정의들
-export * from './auction';
 export * from './users';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

이전 prisma 버전에서의 코드로 롤백, params 비동기 처리    
- params.id를 비동기로 처리하여 안정성을 높임
- 이전 prisma 버전에서의 코드로 롤백

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

경매 API 구현을 이전 Prisma 버전으로 되돌리고, 파라미터 처리 개선, UI에서 정렬 기능 복원, 디버그 로깅 추가.

버그 수정:
- 안정적인 ID 검색을 위해 경매 상세 정보 엔드포인트에서 동적 params.id를 기다립니다.

개선 사항:
- 홈 선택 상자에서 전체 정렬 옵션 세트를 복원하고 Zustand를 통해 정렬 변경 핸들러를 연결합니다.
- 요청 시작, 파라미터 값, 성공 횟수 및 오류 세부 정보에 대한 콘솔 로그를 경매 목록 API에 추가합니다.
- 경매 목록 및 상세 정보 엔드포인트에 대한 이전 Prisma 기반 쿼리 코드로 되돌립니다.
- 더 이상 사용되지 않는 경매 유형 내보내기를 제거하고 SortOption 가져오기 경로를 새 유형 모듈로 업데이트합니다.

잡일:
- 주석 처리된 코드를 정리하고 사용하지 않는 API 및 유형 내보내기를 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert auction API implementation to the previous Prisma version while improving parameter handling, restoring sort functionality in the UI, and adding debug logging.

Bug Fixes:
- Await the dynamic params.id in the auction detail endpoint to ensure reliable ID retrieval.

Enhancements:
- Restore full set of sort options in the home select box and wire up the sort change handler via Zustand.
- Add console logs to the auction list API for request start, parameter values, success count, and error details.
- Revert to prior Prisma-based query code for auction listing and detail endpoints.
- Remove the outdated auction type export and update SortOption import path to the new types module.

Chores:
- Clean up commented code and remove unused API and type exports.

</details>