### PR TITLE
[Fix]: 워크플로우 시크릿토큰 변경

### DIFF
--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: miniseung/KFE3-e2e-WONDERFUL
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.PERSONAL_REPO_TOKEN }}
           fetch-depth: 0
 
       - name: Setup Git
@@ -44,7 +44,7 @@ jobs:
       - name: Add PR author's fork as remote
         env:
           PR_AUTHOR: ${{ steps.pr-info.outputs.pr_author }}
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_REPO_TOKEN }}
         run: |
           # PR 작성자의 포크 레포를 remote로 추가
           PR_FORK_URL="https://$GITHUB_TOKEN@github.com/$PR_AUTHOR/KFE3-e2e-WONDERFUL.git"
@@ -183,7 +183,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: miniseung/KFE3-e2e-WONDERFUL
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.PERSONAL_REPO_TOKEN }}
           fetch-depth: 0
 
       - name: Get PR info for cleanup


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
워크플로우 토큰 PERSONAL_ACCESS_TOKEN(개인레포)을 PERSONAL_REPO_TOKEN(팀레포)으로 변경
수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

CI:
- `.github/workflows/pr-preview-deploy.yml`에서 `secrets.PERSONAL_ACCESS_TOKEN`의 모든 항목을 `secrets.PERSONAL_REPO_TOKEN`으로 대체합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Replace all occurrences of secrets.PERSONAL_ACCESS_TOKEN with secrets.PERSONAL_REPO_TOKEN in .github/workflows/pr-preview-deploy.yml

</details>