### PR TITLE
[fix] 경매 조회 관련 리페칭 이슈 해결

### DIFF
--- a/apps/web/src/components/auction-detail/item-images.tsx
+++ b/apps/web/src/components/auction-detail/item-images.tsx
@@ -17,15 +17,19 @@ const ItemImages = ({ urls }: ItemImagesProps) => {
   const [count, setCount] = React.useState(0);
 
   React.useEffect(() => {
-    if (!api) {
-      return;
-    }
-    setCount(api.scrollSnapList().length);
-    setCurrent(api.selectedScrollSnap() + 1);
+    if (!api) return;
+
+    const timer = setTimeout(() => {
+      setCount(api.scrollSnapList().length);
+      setCurrent(api.selectedScrollSnap() + 1);
+    }, 50);
+
     api.on('select', () => {
       setCurrent(api.selectedScrollSnap() + 1);
     });
-  }, [api]);
+
+    return () => clearTimeout(timer);
+  }, [api, urls]);
 
   return (
     <Carousel className="relative w-full" setApi={setApi}>

--- a/apps/web/src/components/common/auction-item-List.tsx
+++ b/apps/web/src/components/common/auction-item-List.tsx
@@ -7,6 +7,7 @@ import { useAuctions } from '@/hooks/queries/auction/useAuctions';
 import { SortOption } from '@/lib/types/auction-prisma';
 
 import { AuctionItemProps } from '@/types/auction';
+import { useEffect } from 'react';
 
 interface AuctionItemListProps {
   selectedCategoryId?: string;
@@ -33,6 +34,10 @@ const AuctionItemList = ({
     sortOption,
     includeCompleted
   );
+
+  useEffect(() => {
+    if (refetch) refetch();
+  }, []);
 
   // 데이터를 AuctionItemCard에서 사용할 수 있는 형태로 변환
   const convertToAuctionItemProps = (auction: any): AuctionItemProps => {

--- a/apps/web/src/hooks/auction/useEditAuction.tsx
+++ b/apps/web/src/hooks/auction/useEditAuction.tsx
@@ -3,7 +3,7 @@ import { FormErrorMessageType } from '@/types/auction';
 import { useRouter } from 'next/navigation';
 import { CreateAuctionFormData, createAuctionSchema } from '@/lib/schema/auction.schema';
 import { updateAuction } from '@/lib/actions/auction.action';
-import { deleteImage, uploadMultipleImages } from '@/lib/supabase/storage';
+import { deleteFolder, uploadMultipleImages } from '@/lib/supabase/storage';
 
 const useEditAuction = (itemId: string) => {
   const [errors, setErrors] = useState<FormErrorMessageType>({});
@@ -63,7 +63,7 @@ const useEditAuction = (itemId: string) => {
         const auctionId = await updateAuction(phasedData, itemId);
         if (!auctionId) throw new Error('게시글 수정에 실패했습니다.');
 
-        const deleteImages = await deleteImage('auction-images', auctionId);
+        const deleteImages = await deleteFolder('auction-images', auctionId);
         if (!deleteImages) throw new Error('이미지 초기화에 실패했습니다.');
 
         const uploadedUrls = await uploadMultipleImages(files, 'auction-images', auctionId);


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
closes #219 

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

경매 데이터 재 가져오기 문제 수정 및 경매 이미지 정리 보장

버그 수정:
- `deleteImage` 대신 `deleteFolder`를 사용하여 경매의 모든 이미지를 올바르게 삭제합니다.

개선 사항:
- 초기 캐러셀 카운트 초기화를 지연시키고 이미지 URL이 변경될 때마다 업데이트합니다.
- 컴포넌트 마운트 시 경매 목록을 다시 가져오도록 트리거하여 최신 데이터를 로드합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix auction data re-fetching issues and ensure proper cleanup of auction images

Bug Fixes:
- Use deleteFolder instead of deleteImage to properly clear all images for an auction

Enhancements:
- Delay initial carousel count initialization and update it whenever image URLs change
- Trigger a refetch of the auction list on component mount to load the latest data

</details>