### PR TITLE
[feat] 마이페이지 관심목록 페이지 ui 구현

### DIFF
--- a/apps/web/app/profile/wishlist/page.tsx
+++ b/apps/web/app/profile/wishlist/page.tsx
@@ -1,0 +1,7 @@
+import WishlistPage from '@/views/profile/WishlistPage';
+
+const Page = () => {
+  return <WishlistPage />;
+};
+
+export default Page;

--- a/apps/web/src/components/common/auction-card/index.ts
+++ b/apps/web/src/components/common/auction-card/index.ts
@@ -1,0 +1,3 @@
+export { default as BadgeBidStatus } from './badge-bid-status';
+export { default as AuctionItemCard } from './card';
+export { default as AuctionItemList } from './list';

--- a/apps/web/src/components/common/button/create-auction.tsx
+++ b/apps/web/src/components/common/button/create-auction.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+
 import { Plus } from 'lucide-react';
+
 import { FloatButton } from '@/components/ui/float-button';
 
 const CreateAuctionButton = () => {

--- a/apps/web/src/components/common/button/index.ts
+++ b/apps/web/src/components/common/button/index.ts
@@ -1,0 +1,2 @@
+export { default as CreateAuctionButton } from './create-auction';
+export { default as ButtonMore } from './more';

--- a/apps/web/src/components/common/button/more.tsx
+++ b/apps/web/src/components/common/button/more.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { EllipsisVertical } from 'lucide-react';
+
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui';
 
 interface ButtonMoreProps {
@@ -14,6 +15,11 @@ export interface ButtonMoreItem {
 }
 
 const ButtonMore = ({ items }: ButtonMoreProps) => {
+  const handleItemClick = (item: ButtonMoreItem) => {
+    if (item.onClick) {
+      item.onClick();
+    }
+  };
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -24,7 +30,11 @@ const ButtonMore = ({ items }: ButtonMoreProps) => {
       <PopoverContent className="w-25 py-2">
         <ul className="space-y-2">
           {items.map((item) => (
-            <li key={item.id} onClick={item.onClick} className="cursor-pointer text-center">
+            <li
+              key={item.id}
+              onClick={() => handleItemClick(item)}
+              className="cursor-pointer text-center"
+            >
               {item.title}
             </li>
           ))}

--- a/apps/web/src/components/common/profile/card.tsx
+++ b/apps/web/src/components/common/profile/card.tsx
@@ -1,4 +1,4 @@
-import ProfileImage from '@/components/common/profile/image';
+import { ProfileImage } from '@/components/common/profile';
 
 interface ProfileCardProps {
   nickname: string;
@@ -6,10 +6,12 @@ interface ProfileCardProps {
   children: React.ReactNode;
 }
 
-export const ProfileCard = ({ nickname, profileImg, children }: ProfileCardProps) => (
+const ProfileCard = ({ nickname, profileImg, children }: ProfileCardProps) => (
   <div className="flex w-full items-center gap-3 bg-white px-4 py-2">
     <ProfileImage src={profileImg} alt={`${nickname} 프로필 이미지`} />
     <span className="text-base font-medium">{nickname}</span>
     <div className="ml-auto">{children}</div>
   </div>
 );
+
+export default ProfileCard;

--- a/apps/web/src/components/common/profile/index.ts
+++ b/apps/web/src/components/common/profile/index.ts
@@ -1,0 +1,4 @@
+export { default as ProfileCard } from './card';
+
+export { default as ProfileImage } from './image';
+export { default as MenuList } from './menu-list';

--- a/apps/web/src/components/common/profile/menu-list.tsx
+++ b/apps/web/src/components/common/profile/menu-list.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Link from 'next/link';
 
 interface MenuItem {
@@ -35,7 +33,7 @@ const menuSections: MenuSection[] = [
   },
 ];
 
-export const MenuList = () => {
+const MenuList = () => {
   return (
     <nav aria-label="마이페이지 메뉴 목록">
       {menuSections.map((section) => (
@@ -58,3 +56,5 @@ export const MenuList = () => {
     </nav>
   );
 };
+
+export default MenuList;

--- a/apps/web/src/components/common/tab/basic.tsx
+++ b/apps/web/src/components/common/tab/basic.tsx
@@ -1,5 +1,6 @@
-import { TabBasic, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tab-basic';
 import React from 'react';
+
+import { TabBasic, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tab-basic';
 
 interface TabProps {
   tabs: TabItem[];

--- a/apps/web/src/components/common/tab/index.ts
+++ b/apps/web/src/components/common/tab/index.ts
@@ -1,0 +1,2 @@
+export { default as TabBasic } from './basic';
+export { default as TabListFilter } from './list-filter';

--- a/apps/web/src/components/common/tab/list-filter.tsx
+++ b/apps/web/src/components/common/tab/list-filter.tsx
@@ -25,7 +25,7 @@ const TabListFilter = ({ items, selectedCategoryId, onCategoryChange }: Categori
   const defaultValue = selectedCategoryId !== undefined ? selectedCategoryId : items[0]?.id || '';
   return (
     <FilterTabs value={defaultValue} onValueChange={handleTabsValueChange}>
-      <FilterTabsList className="my-3">
+      <FilterTabsList className="my-3 w-fit">
         {items.map(({ id, name }) => {
           return (
             <FilterTabsTrigger key={id} value={id}>

--- a/apps/web/src/lib/constants/tabs.ts
+++ b/apps/web/src/lib/constants/tabs.ts
@@ -9,4 +9,41 @@ export const FALLBACK_CATEGORIES: TabItem[] = [
   { id: '06ab1238-e817-4faf-9652-8dfa6eead9d4', name: '자동차/오토바이' },
   { id: '0920045d-c662-48b0-a503-c2e1eea0ac22', name: '의류/액세서리' },
   { id: '25052d9f-c32d-4206-88da-6130cedc0666', name: '카메라/영상' },
+  { id: '32f83fa6-80be-43f6-880e-af187a9c6e80', name: '생활용품' },
+  { id: '7c26ada6-c410-4b89-a008-faf4bfa56623', name: '전자제품' },
+  { id: '8533037d-f684-4a39-bf64-b7f7765ec1a9', name: '스포츠/레저' },
+  { id: '89f2b7b7-f8c4-4637-8005-54de5c963940', name: '도서/음반' },
+  { id: '9734e870-1cfa-4c97-a584-58c99ab0bd07', name: '부품/소모품' },
 ];
+
+// 경매 상태 타입
+export type AuctionStatus = 'ACTIVE' | 'COMPLETED' | 'CANCELLED' | 'EXPIRED';
+
+// 탭 ID 타입
+export type TabId = 'all' | 'ongoing' | 'completed' | 'cancelled';
+
+// 각 탭에 매핑되는 상태들
+export const TAB_STATUS_MAP: Record<TabId, AuctionStatus[]> = {
+  all: ['ACTIVE', 'COMPLETED', 'CANCELLED', 'EXPIRED'],
+  ongoing: ['ACTIVE'],
+  completed: ['COMPLETED'],
+  cancelled: ['CANCELLED', 'EXPIRED'],
+} as const;
+
+// 기본 탭 (3개) - 전체/경매중/경매완료
+export const AUCTION_TABS_BASIC: Array<{ id: TabId; name: string }> = [
+  { id: 'all', name: '전체' },
+  { id: 'ongoing', name: '경매중' },
+  { id: 'completed', name: '경매완료' },
+];
+
+// 확장 탭 (4개) - 전체/경매중/경매완료/취소&환불
+export const AUCTION_TABS_EXTENDED: Array<{ id: TabId; name: string }> = [
+  { id: 'all', name: '전체' },
+  { id: 'ongoing', name: '경매중' },
+  { id: 'completed', name: '경매완료' },
+  { id: 'cancelled', name: '취소&환불' },
+];
+
+// 기존 호환성을 위해 유지
+export const AUCTION_TABS = AUCTION_TABS_EXTENDED;

--- a/apps/web/src/views/HomePage.tsx
+++ b/apps/web/src/views/HomePage.tsx
@@ -2,9 +2,9 @@
 
 import { useMemo, useState } from 'react';
 
-import AuctionItemList from '@/components/common/auction-card/list';
-import Categories from '@/components/common/tab/list-filter';
-import CreateAuctionButton from '@/components/common/button/create-auction';
+import { AuctionItemList } from '@/components/common/auction-card';
+import { CreateAuctionButton } from '@/components/common/button';
+import { TabListFilter } from '@/components/common/tab';
 
 import { useCategories } from '@/hooks/queries/category/useCategories';
 
@@ -50,7 +50,7 @@ const HomePage = () => {
   return (
     <section>
       {/* 카테고리 필터링 탭 */}
-      <Categories
+      <TabListFilter
         items={categories}
         selectedCategoryId={selectedCategoryId}
         onCategoryChange={handleCategoryChange}

--- a/apps/web/src/views/ProfilePage.tsx
+++ b/apps/web/src/views/ProfilePage.tsx
@@ -1,10 +1,11 @@
 'use client';
 import { useRouter } from 'next/navigation';
+
 import { Pen } from 'lucide-react';
 
-import { MenuList } from '@/components/common/profile/menu-list';
-import { ProfileCard } from '@/components/common/profile/card';
+import { MenuList, ProfileCard } from '@/components/common/profile';
 import { Button } from '@/components/ui/button';
+
 import { signOutAction } from '@/lib/actions/auth.action';
 
 const ProfilePage = () => {

--- a/apps/web/src/views/profile/WishlistPage.tsx
+++ b/apps/web/src/views/profile/WishlistPage.tsx
@@ -1,0 +1,34 @@
+'use client';
+// 마이페이지 - 관심목록 페이지
+import { useState } from 'react';
+
+import { AuctionItemList } from '@/components/common/auction-card';
+import { TabListFilter } from '@/components/common/tab';
+
+import { AUCTION_TABS, AUCTION_TABS_BASIC, TAB_STATUS_MAP, TabId } from '@/lib/constants/tabs';
+
+const WishlistPage = () => {
+  const [selectedTab, setSelectedTab] = useState<TabId>(AUCTION_TABS[0]?.id || 'all');
+
+  const handleTabChange = (tabId: string) => {
+    setSelectedTab(tabId as TabId);
+  };
+
+  return (
+    <div>
+      {/* 상단 헤더 */}
+      {/* <div className="absolute left-0 top-0 z-10 w-full">
+        <Header title="판매 내역" />
+      </div> */}
+
+      <TabListFilter
+        items={AUCTION_TABS_BASIC}
+        selectedCategoryId={selectedTab}
+        onCategoryChange={handleTabChange}
+      />
+      <AuctionItemList selectedStatuses={TAB_STATUS_MAP[selectedTab]} includeCompleted={true} />
+    </div>
+  );
+};
+
+export default WishlistPage;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
closes #233 
## 📋 작업 내용

팀 규칙에 맞는 코드 스타일 변경 및 import 에러 해결
관심목록 페이지 ui 구현

##  공통으로 쓸 수 있는 구조

- 상품검색 - 검색결과 리스트
- 마이페이지 - 판매내역
- 상대방 프로필 조회

## 메인 홈에서 옥션 데이터를 가져오길래 추가 조건 없이 데이터를 불러오도록 값만 받았습니다.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img src="https://github.com/user-attachments/assets/0676bdc4-b060-4729-bc42-c2d515b20a17" width="350px" />


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
