### PR TITLE
[fix] Next.js + Supabase manifest.webmanifest 브라우저 파싱 에러 해결

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -2,6 +2,7 @@
 // 들어오는 요청에 따라 응답을 수정하거나 리다이렉트, 헤더 수정, 직접 응답 등을 할 수 있음
 
 import { type NextRequest } from 'next/server';
+
 import { updateSession } from './src/lib/supabase/middleware';
 
 export async function middleware(request: NextRequest) {
@@ -16,10 +17,12 @@ export const config = {
      * - _next/image (이미지 최적화 파일)
      * - favicon.ico (파비콘 파일)
      * - manifest.json (PWA 매니페스트)
+     * - manifest.webmanifest (PWA 매니페스트)
      * - service-worker.js (서비스 워커)
+     * - firebase-messaging-sw.js (푸시 알림 서비스 워커)
      * - 이미지 파일들 (svg, png, jpg, jpeg, gif, webp)
      * - certificates 폴더 (인증서 관련 파일)
      */
-    '/((?!_next/static|_next/image|favicon.ico|manifest.json|service-worker.js|certificates|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|manifest.json|service-worker.js|firebase-messaging-sw.js|certificates|.*\\.(?:svg|png|jpg|jpeg|gif, webp)$).*)',
   ],
 };

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -1,5 +1,6 @@
-import { createServerClient } from '@supabase/ssr';
 import { NextRequest, NextResponse } from 'next/server';
+
+import { createServerClient } from '@supabase/ssr';
 
 export async function updateSession(request: NextRequest) {
   // supabaseResponse 변수로 관리
@@ -39,6 +40,26 @@ export async function updateSession(request: NextRequest) {
   } = await supabase.auth.getUser();
 
   const { pathname } = request.nextUrl;
+
+  // 정적 파일들과 PWA 관련 파일들은 인증 없이 허용
+  const isStaticFile =
+    pathname.includes('manifest') ||
+    pathname.includes('.js') ||
+    pathname.includes('.json') ||
+    pathname.includes('.ico') ||
+    pathname.includes('.png') ||
+    pathname.includes('.svg') ||
+    pathname.includes('.webp') ||
+    pathname.includes('.jpg') ||
+    pathname.includes('.jpeg') ||
+    pathname.includes('.gif');
+
+  if (isStaticFile) {
+    if (process.env.NODE_ENV === 'development') {
+      console.log(`📁 [Static File] ${pathname} - 인증 없이 허용`);
+    }
+    return supabaseResponse;
+  }
 
   //개발 환경 디버깅
   if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

PWA 및 기타 정적 자산이 Supabase 세션 미들웨어를 우회하도록 허용하여 manifest.webmanifest에 대한 브라우저 파싱 오류를 수정합니다.

버그 수정:
- manifest.webmanifest 파싱 오류를 방지하기 위해 정적 파일 및 PWA 자산에 대한 Supabase 인증을 우회합니다.
- `manifest.webmanifest` 및 `firebase-messaging-sw.js`를 미들웨어 제외 패턴에 포함합니다.

개선 사항:
- 개발 환경에서 인증 없이 정적 파일 요청을 로깅합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow PWA and other static assets to bypass Supabase session middleware to fix browser parsing errors for manifest.webmanifest.

Bug Fixes:
- Bypass Supabase authentication for static files and PWA assets to prevent manifest.webmanifest parsing errors
- Include manifest.webmanifest and firebase-messaging-sw.js in middleware exclusion patterns

Enhancements:
- Log static file requests without authentication in development environment

</details>