### PR TITLE
[chore] components/common/index.ts 생성 및 정리

### DIFF
--- a/apps/web/src/components/common/attach-images/attach-images-thumbnail.tsx
+++ b/apps/web/src/components/common/attach-images/attach-images-thumbnail.tsx
@@ -1,6 +1,7 @@
 import { X } from 'lucide-react';
 
 import Thumbnail from '@/components/ui/thumbnail';
+
 import { AttacedAuctionImageProps } from '@/lib/types/auction-prisma';
 
 const AttacedImagesThumbnail = ({ url, handleDelete }: AttacedAuctionImageProps) => {

--- a/apps/web/src/components/common/attach-images/attach-images.tsx
+++ b/apps/web/src/components/common/attach-images/attach-images.tsx
@@ -2,11 +2,11 @@
 
 import { useEffect, useState } from 'react';
 
-import AttacedImagesThumbnail from '@/components/common/attach-images/attach-images-thumbnail';
-import AttachImagesInput from '@/components/common/attach-images/attach-images-input';
-
 import deletePreviewImage from '@/hooks/auction/useDeletePreview';
 import useOnChagePreview from '@/hooks/auction/useOnChangePreview';
+
+import AttachImagesInput from './attach-images-input';
+import AttacedImagesThumbnail from './attach-images-thumbnail';
 
 interface ImagesUploaderProps {
   id: string;

--- a/apps/web/src/components/common/auction-card/card.tsx
+++ b/apps/web/src/components/common/auction-card/card.tsx
@@ -2,13 +2,14 @@
 
 import Link from 'next/link';
 
-import BadgeBidStatus from '@/components/common/auction-card/badge-bid-status';
-import Thumbnail from '@/components/ui/thumbnail';
 import { Badge } from '@/components/ui/badge';
+import Thumbnail from '@/components/ui/thumbnail';
 
 import useCountdown from '@/hooks/common/useCountdown';
 
 import { AuctionItemProps } from '@/types/auction';
+
+import BadgeBidStatus from './badge-bid-status';
 
 const renderTimeBadge = ({
   hours,

--- a/apps/web/src/components/common/auction-card/index.ts
+++ b/apps/web/src/components/common/auction-card/index.ts
@@ -1,3 +1,0 @@
-export { default as BadgeBidStatus } from './badge-bid-status';
-export { default as AuctionItemCard } from './card';
-export { default as AuctionItemList } from './list';

--- a/apps/web/src/components/common/auction-card/list.tsx
+++ b/apps/web/src/components/common/auction-card/list.tsx
@@ -2,14 +2,14 @@
 
 import { useEffect, useMemo } from 'react';
 
-import { AuctionItemCard } from '@/components/common/auction-card';
-
 import { useAuctions } from '@/hooks/queries/auction/useAuctions';
 
 import { AuctionStatus } from '@/lib/constants/tabs';
 import { AuctionListItem, SortOption } from '@/lib/types/auction-prisma';
 
 import { AuctionItemProps } from '@/types/auction';
+
+import AuctionItemCard from './card';
 
 interface AuctionItemListProps {
   selectedCategoryId?: string;

--- a/apps/web/src/components/common/button/index.ts
+++ b/apps/web/src/components/common/button/index.ts
@@ -1,2 +1,0 @@
-export { default as CreateAuctionButton } from './create-auction';
-export { default as ButtonMore } from './more';

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -1,26 +1,26 @@
-export * from './attach-images/attach-images';
-export * from './attach-images/attach-images-input';
-export * from './attach-images/attach-images-thumbnail';
+export { default as AttachImages } from './attach-images/attach-images';
+export { default as AttachImagesInput } from './attach-images/attach-images-input';
+export { default as AttachImagesThumbnail } from './attach-images/attach-images-thumbnail';
 
-export * from './auction-card/badge-bid-status';
-export * from './auction-card/card';
-export * from './auction-card/list';
+export { default as BadgeBidStatus } from './auction-card/badge-bid-status';
+export { default as AuctionCard } from './auction-card/card';
+export { default as AuctionItemList } from './auction-card/list';
 
-export * from './button/create-auction';
-export * from './button/more';
+export { default as CreateAuctionButton } from './button/create-auction';
+export { default as MoreButton } from './button/more';
 
-export * from './input/basic';
-export * from './input/icon';
+export { default as BasicInput } from './input/basic';
+export { default as IconInput } from './input/icon';
 
-export * from './messages/error-msg';
-export * from './messages/notice';
+export { default as ErrorMsg } from './messages/error-msg';
+export { default as Notice } from './messages/notice';
 
-export * from './profile/card';
-export * from './profile/image';
-export * from './profile/menu-list';
+export { default as ProfileCard } from './profile/card';
+export { default as ProfileImage } from './profile/image';
+export { default as MenuList } from './profile/menu-list';
 
-export * from './select/basic';
-export * from './select/category';
-export * from './select/min-unit';
+export { default as Select } from './select/basic';
+export { default as CategorySelectBox } from './select/category';
+export { default as MinUnitSelectBox } from './select/min-unit';
 
-export * from './tab/list-filter';
+export { default as TabListFilter } from './tab/list-filter';

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -1,0 +1,26 @@
+export * from './attach-images/attach-images';
+export * from './attach-images/attach-images-input';
+export * from './attach-images/attach-images-thumbnail';
+
+export * from './auction-card/badge-bid-status';
+export * from './auction-card/card';
+export * from './auction-card/list';
+
+export * from './button/create-auction';
+export * from './button/more';
+
+export * from './input/basic';
+export * from './input/icon';
+
+export * from './messages/error-msg';
+export * from './messages/notice';
+
+export * from './profile/card';
+export * from './profile/image';
+export * from './profile/menu-list';
+
+export * from './select/basic';
+export * from './select/category';
+export * from './select/min-unit';
+
+export * from './tab/list-filter';

--- a/apps/web/src/components/common/profile/card.tsx
+++ b/apps/web/src/components/common/profile/card.tsx
@@ -1,4 +1,4 @@
-import { ProfileImage } from '@/components/common/profile';
+import ProfileImage from './image';
 
 interface ProfileCardProps {
   nickname: string;

--- a/apps/web/src/components/common/profile/index.ts
+++ b/apps/web/src/components/common/profile/index.ts
@@ -1,4 +1,0 @@
-export { default as ProfileCard } from './card';
-
-export { default as ProfileImage } from './image';
-export { default as MenuList } from './menu-list';

--- a/apps/web/src/components/common/select/basic.tsx
+++ b/apps/web/src/components/common/select/basic.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import {
   Select,
   SelectContent,
@@ -23,7 +21,7 @@ interface SelectBoxProps {
   onValueChange?: (value: string) => void;
 }
 
-export const SelectBox = ({
+const SelectBox = ({
   options,
   placeholder = 'Select an option',
   className,
@@ -53,6 +51,7 @@ export const SelectBox = ({
   );
 };
 
+export default SelectBox;
 // 사용 예시:
 // export const ExampleUsage = () => {
 //   const fruitOptions = [

--- a/apps/web/src/components/common/select/category.tsx
+++ b/apps/web/src/components/common/select/category.tsx
@@ -2,9 +2,11 @@
 
 import { useState } from 'react';
 
-import { SelectBox } from '@/components/common/select/basic';
 import { FALLBACK_CATEGORIES } from '@/lib/constants/tabs';
+
 import { AuctionFormSelectProps } from '@/types/auction';
+
+import { SelectBox } from './basic';
 
 // const stateOptions = FALLBACK_CATEGORIES.slice(1);
 const stateOptions = FALLBACK_CATEGORIES.slice(1).map((category) => ({

--- a/apps/web/src/components/common/select/category.tsx
+++ b/apps/web/src/components/common/select/category.tsx
@@ -6,7 +6,7 @@ import { FALLBACK_CATEGORIES } from '@/lib/constants/tabs';
 
 import { AuctionFormSelectProps } from '@/types/auction';
 
-import { SelectBox } from './basic';
+import SelectBox from './basic';
 
 // const stateOptions = FALLBACK_CATEGORIES.slice(1);
 const stateOptions = FALLBACK_CATEGORIES.slice(1).map((category) => ({

--- a/apps/web/src/components/common/select/min-unit.tsx
+++ b/apps/web/src/components/common/select/min-unit.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { AuctionFormSelectProps } from '@/lib/types/auction';
 
-import { SelectBox } from './basic';
+import SelectBox from './basic';
 
 const stateOptions = [
   { value: '500', label: '500' },

--- a/apps/web/src/components/common/select/min-unit.tsx
+++ b/apps/web/src/components/common/select/min-unit.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from 'react';
 
-import { SelectBox } from '@/components/common/select/basic';
 import { AuctionFormSelectProps } from '@/lib/types/auction';
+
+import { SelectBox } from './basic';
 
 const stateOptions = [
   { value: '500', label: '500' },

--- a/apps/web/src/components/common/tab/index.ts
+++ b/apps/web/src/components/common/tab/index.ts
@@ -1,1 +1,0 @@
-export { default as TabListFilter } from './list-filter';

--- a/apps/web/src/views/AuctionPage.tsx
+++ b/apps/web/src/views/AuctionPage.tsx
@@ -7,7 +7,7 @@ import { useParams } from 'next/navigation';
 import { MessageSquareMore } from 'lucide-react';
 
 import { BidForm, BidTable, ItemImages, ItemInformation } from '@/components/auction-detail';
-import { ProfileCard } from '@/components/common/profile';
+import { ProfileCard } from '@/components/common';
 import { Button } from '@/components/ui/button';
 
 import { useAuctionDetail } from '@/hooks/queries/auction/useAuctions';

--- a/apps/web/src/views/CreateAcutionPage.tsx
+++ b/apps/web/src/views/CreateAcutionPage.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { CircleAlert } from 'lucide-react';
+
 import CreateAuctionForm from '@/components/auction-create/form-create';
-import Notice from '@/components/common/messages/notice';
+import { Notice } from '@/components/common';
 import { Button } from '@/components/ui';
+
 import useCreateAuction from '@/hooks/auction/useCreateAuction';
 
 const CreateAuctionPage = () => {

--- a/apps/web/src/views/HomePage.tsx
+++ b/apps/web/src/views/HomePage.tsx
@@ -2,9 +2,7 @@
 
 import { useMemo, useState } from 'react';
 
-import { AuctionItemList } from '@/components/common/auction-card';
-import { CreateAuctionButton } from '@/components/common/button';
-import { TabListFilter } from '@/components/common/tab';
+import { AuctionItemList, CreateAuctionButton, TabListFilter } from '@/components/common';
 
 import { useCategories } from '@/hooks/queries/category/useCategories';
 

--- a/apps/web/src/views/ProfilePage.tsx
+++ b/apps/web/src/views/ProfilePage.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/navigation';
 
 import { Pen } from 'lucide-react';
 
-import { MenuList, ProfileCard } from '@/components/common/profile';
+import { MenuList, ProfileCard } from '@/components/common';
 import { Button } from '@/components/ui/button';
 
 import { signOutAction } from '@/lib/actions/auth.action';

--- a/apps/web/src/views/profile/TradePage.tsx
+++ b/apps/web/src/views/profile/TradePage.tsx
@@ -2,8 +2,7 @@
 // 마이페이지 - 판매 내역 페이지
 import { useState } from 'react';
 
-import { AuctionItemList } from '@/components/common/auction-card';
-import { TabListFilter } from '@/components/common/tab';
+import { AuctionItemList, TabListFilter } from '@/components/common';
 
 import { AUCTION_TABS, AUCTION_TABS_EXTENDED, TAB_STATUS_MAP, TabId } from '@/lib/constants/tabs';
 

--- a/apps/web/src/views/profile/WishlistPage.tsx
+++ b/apps/web/src/views/profile/WishlistPage.tsx
@@ -2,8 +2,7 @@
 // 마이페이지 - 관심목록 페이지
 import { useState } from 'react';
 
-import { AuctionItemList } from '@/components/common/auction-card';
-import { TabListFilter } from '@/components/common/tab';
+import { AuctionItemList, TabListFilter } from '@/components/common';
 
 import { AUCTION_TABS, AUCTION_TABS_BASIC, TAB_STATUS_MAP, TabId } from '@/lib/constants/tabs';
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
closes #255 
## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

`components/common`에 중앙 배럴 파일을 추가하고 컴포넌트 내보내기를 간소화하기 위해 import를 리팩터링합니다.

개선 사항:
- 모든 공통 하위 컴포넌트를 다시 내보내기 위해 `components/common/index.ts`를 생성합니다.
- `auction-card`, `button`, `profile` 및 `tab` 아래의 중복된 하위 폴더 `index.ts` 파일을 제거합니다.
- 상대 경로와 새로운 배럴 내보내기를 사용하도록 공통 컴포넌트 전체에서 import 문을 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a central barrel file in components/common and refactor imports to streamline component exports

Enhancements:
- Create components/common/index.ts to re-export all common sub-components
- Remove redundant subfolder index.ts files under auction-card, button, profile, and tab
- Update import statements across common components to use relative paths and the new barrel export

</details>