### PR TITLE
[refactor] view 파일 app page로 이동 및 infomation 컴포넌트 재정리

### DIFF
--- a/apps/web/app/auction/[id]/page.tsx
+++ b/apps/web/app/auction/[id]/page.tsx
@@ -1,7 +1,13 @@
-import AuctionPage from '@/views/AuctionPage';
+import AuctionDetailContainer from '@/components/auction-detail/container';
 
-const Page = async () => {
-  return <AuctionPage />;
+const Page = () => {
+  return (
+    <>
+      <section className="flex flex-col items-center gap-1 px-0">
+        <AuctionDetailContainer />
+      </section>
+    </>
+  );
 };
 
 export default Page;

--- a/apps/web/src/components/auction-detail/container.tsx
+++ b/apps/web/src/components/auction-detail/container.tsx
@@ -1,4 +1,14 @@
 'use client';
+/**
+ * Todo
+ * 1. 전역상태 관리
+ *    -> 현재 최고 입찰가 = bid-form의 최소 입찰 금액
+ *    -> Item 데이터 변환 : 내려줘야하는 컴포넌트 별 prop 기준으로 다시 재작성.
+ *    -> store로 처리할 수 있는 부분은 prop은 최소화로 쓰기
+ * 2. error 처리는 useEffect 안에서 처리! -> 재로딩 컴포넌트 따로 만들어서 호출하기
+ * 3. suspense 컴포넌트 따로 만들어서 lazy.loading 처리
+ * 4. 현재 로그인한 유저의 ID를 가져오는 로직 필요 (useAuthStore)
+ */
 
 import { useEffect } from 'react';
 
@@ -6,7 +16,7 @@ import { useParams } from 'next/navigation';
 
 import { MessageSquareMore } from 'lucide-react';
 
-import { BidForm, BidTable, ItemImages, ItemInformation } from '@/components/auction-detail';
+import { BidForm, ItemImages, ItemInformation } from '@/components/auction-detail';
 import { ProfileCard } from '@/components/common';
 import { Button } from '@/components/ui/button';
 
@@ -14,8 +24,7 @@ import { useAuctionDetail } from '@/hooks/queries/auction/useAuctions';
 
 import { ItemInfo } from '@/lib/types/auction';
 
-const AuctionPage = () => {
-  // Todo: 현재 로그인한 유저의 ID를 가져오는 로직 필요 (useAuthStore)
+const AuctionDetailContainer = () => {
   const userId = undefined;
 
   const params = useParams();
@@ -58,7 +67,6 @@ const AuctionPage = () => {
 
   const auction = auctionDetailData.data;
 
-  // 이미지 배열 처리 함수
   const processImages = (): string[] => {
     if (!auction?.auctionImages?.length) return ['/no-image.png'];
     // 모든 레코드의 urls를 하나의 배열로 합치기
@@ -71,6 +79,8 @@ const AuctionPage = () => {
     title: auction.title,
     status: auction.status,
     endTime: auction.endTime.toString(),
+    description: auction.description || '',
+
     // 추가 필요한 필드들
     startPrice: auction.auctionPrice?.startPrice || 0,
     currentPrice: auction.auctionPrice?.currentPrice || 0,
@@ -99,19 +109,13 @@ const AuctionPage = () => {
             채팅하기
           </Button>
         </ProfileCard>
-        <ItemInformation item={item} />
-        <div className="my-6 w-full space-y-6 px-4">
-          <div className="">{auction.description}</div>
-          <div className="bg-primary-50/80 rounded-sm px-2 py-1">
-            <BidTable itemId={id as string} />
-          </div>
-        </div>
+        <ItemInformation item={item} id={id as string} />
       </section>
-      <footer className="sticky bottom-0 z-50 w-full bg-white">
+      <section className="sticky bottom-0 z-50 w-full bg-white">
         <BidForm currentPrice={item.currentPrice} endTime={auction.endTime} />
-      </footer>
+      </section>
     </>
   );
 };
 
-export default AuctionPage;
+export default AuctionDetailContainer;

--- a/apps/web/src/components/auction-detail/item-information.tsx
+++ b/apps/web/src/components/auction-detail/item-information.tsx
@@ -5,17 +5,21 @@ import useCountdown from '@/hooks/common/useCountdown';
 
 import { formatDate } from '@/lib/utils/date';
 
+import BidTable from './bid-table';
+
 interface ItemInformationProps {
   item: Item;
+  id: string;
 }
 
 export interface Item {
   title: string;
   status: string;
   endTime: string;
+  description: string;
 }
 
-const ItemInformation = ({ item }: ItemInformationProps) => {
+const ItemInformation = ({ item, id }: ItemInformationProps) => {
   const deadline = formatDate(new Date(item.endTime));
 
   // 실시간으로 경매 종료 여부 확인
@@ -42,6 +46,12 @@ const ItemInformation = ({ item }: ItemInformationProps) => {
           <time className="text-sm font-medium text-neutral-400">{deadline}</time>
         </div>
         <Countdown date={new Date(item.endTime)} />
+      </div>
+      <div className="my-6 w-full space-y-6 px-4">
+        <div className="">{item.description}</div>
+        <div className="bg-primary-50/80 rounded-sm px-2 py-1">
+          <BidTable itemId={id} />
+        </div>
       </div>
     </section>
   );

--- a/apps/web/src/lib/types/auction.ts
+++ b/apps/web/src/lib/types/auction.ts
@@ -70,6 +70,7 @@ export interface Item {
   title: string;
   status: string;
   endTime: string;
+  description: string;
 }
 // AuctionPage 컴포넌트에서 사용할 Item 인터페이스 확장
 export interface ItemInfo extends Item {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #272 

## 📋 작업 내용

컴포넌트 분리하려면 전역 store처리까지 필요함.
이 부분은 전략을 세워서 따로 이슈 생성 및 작업 진행이 필요해 보임.
우선 app page로 이동만 진행했습니다.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

Auction 상세 보기 페이지를 리팩토링하여 AuctionPage를 app 디렉토리로 이동하고 이름을 AuctionDetailContainer로 변경합니다. ItemInformation 컴포넌트를 재구성하여 아이템 설명과 입찰 테이블을 내부에 포함시키고, auction 타입에 description 필드를 추가합니다.

개선 사항:
- AuctionPage를 components/auction-detail/container.tsx로 이동 및 이름 변경하고, app/auction/[id]/page.tsx가 AuctionDetailContainer를 사용하도록 조정합니다.
- ItemInformation이 id prop을 받도록 리팩토링하고, 아이템 설명을 렌더링하고 BidTable을 내장합니다.
- auction 타입의 Item 인터페이스를 확장하여 description 속성을 포함합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the auction detail view by moving the AuctionPage into the app directory and renaming it to AuctionDetailContainer, reorganize the ItemInformation component to include the item description and bid table internally, and update the auction types to include the description field.

Enhancements:
- Relocate and rename AuctionPage to components/auction-detail/container.tsx and adjust app/auction/[id]/page.tsx to use AuctionDetailContainer
- Refactor ItemInformation to accept an id prop, render the item description and embed the BidTable
- Extend the Item interface in auction types to include a description property

</details>