### PR TITLE
[Feat] 모달 컨포넌트

### DIFF
--- a/apps/web/src/components/ui/modal.tsx
+++ b/apps/web/src/components/ui/modal.tsx
@@ -17,13 +17,13 @@ const Modal = ({ modalStack, onCloseModal, children }: ModalProps) => {
   // body 스크롤 방지
   useEffect(() => {
     if (modalStack.length > 0) {
-      document.body.style.overflow = 'hidden';
+      document.body.classList.add('overflow-hidden');
     } else {
-      document.body.style.overflow = 'unset';
+      document.body.classList.remove('overflow-hidden');
     }
 
     return () => {
-      document.body.style.overflow = 'unset';
+      document.body.classList.remove('overflow-hidden');
     };
   }, [modalStack.length]);
 
@@ -32,17 +32,16 @@ const Modal = ({ modalStack, onCloseModal, children }: ModalProps) => {
   const modalsContent = modalStack.map((modal, index) => {
     const zIndex = 50 + index;
 
-    const styles = {
-      container: 'fixed inset-0 flex items-end justify-center',
-      modal: `w-full max-w-md h-full bg-white ${modal.className || ''}`,
-    };
-
     return (
-      <div key={modal.id} className={styles.container} style={{ zIndex }}>
+      <div
+        key={modal.id}
+        className="fixed inset-0 flex items-end justify-center"
+        style={{ zIndex }}
+      >
         {/* 모달 컨테이너 */}
-        <div className={`relative ${styles.modal}`}>
-          {/* 닫기 버튼 */}
-          {modal.showCloseButton !== false && (
+        <div className={`relative h-full w-full max-w-md bg-white ${modal.className || ''}`}>
+          {/* 닫기 버튼 - showCloseButton이 true일 때만 표시 */}
+          {modal.showCloseButton && (
             <div className="absolute right-4 top-4 z-10">
               <button
                 onClick={() => onCloseModal(modal.id)}

--- a/apps/web/src/hooks/common/useModal.ts
+++ b/apps/web/src/hooks/common/useModal.ts
@@ -25,6 +25,7 @@ export const useModal = (): UseModalReturn => {
       ...prev,
       {
         id,
+        showCloseButton: false,
         ...options,
       },
     ]);


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
closes #265 
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
모달 배열 사용하여 모달안에서 모달 열고 닫고 할수 있게 작성했습니다.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

재사용 가능한 모달 시스템을 도입합니다. 이 시스템은 React Modal 컴포넌트와 `useModal` 훅으로 구성되어 스택형, 맞춤형 모달 대화 상자를 관리합니다.

새로운 기능:
- 오버레이 및 닫기 버튼이 있는 React 포털을 통해 스택형 전체 화면 및 바텀 시트 모달을 렌더링하는 Modal 컴포넌트를 추가합니다.
- 구성 가능한 옵션으로 ID별 모달을 열고, 닫고, 스택하는 `useModal` 훅을 구현합니다.

개선 사항:
- 모달이 열려 있는 동안 문서 본문 스크롤을 잠급니다.
- 오버레이를 클릭하여 모달을 닫고 모달 높이, 클래스 이름 및 닫기 버튼 가시성을 사용자 정의하는 기능을 지원합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a reusable modal system consisting of a React Modal component and a useModal hook to manage stacked, customizable modal dialogs.

New Features:
- Add Modal component that renders stacked fullscreen and bottom-sheet modals via a React portal with overlay and close buttons.
- Implement useModal hook to open, close, and stack modals by ID with configurable options.

Enhancements:
- Lock document body scrolling while modals are open.
- Support closing modals by clicking the overlay and customizing modal height, class names, and close button visibility.

</details>