### PR TITLE
[feat] 채팅방 메시지 컴포넌트 제작

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -1,0 +1,23 @@
+import { tv } from 'tailwind-variants';
+
+const style = tv({
+  base: 'inline-block p-3 rounded-xl text-sm',
+  variants: {
+    color: {
+      secondary: 'bg-primary-50/70 text-primary-950 max-w-7/12',
+      primary: 'bg-primary-500 text-neutral-50 max-w-2/3',
+      disabled: 'bg-neutral-100 text-primary-950',
+    },
+  },
+});
+
+interface ChatBubbleProps {
+  color: 'primary' | 'secondary' | 'disabled';
+  content: string;
+}
+
+const ChatBubble = ({ color, content }: ChatBubbleProps) => {
+  return <div className={style({ color })}>{content}</div>;
+};
+
+export default ChatBubble;

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -4,7 +4,7 @@ const style = tv({
   base: 'inline-block p-3 rounded-xl text-sm',
   variants: {
     color: {
-      secondary: 'bg-primary-50/70 text-primary-950 max-w-7/12',
+      secondary: 'bg-primary-50/70 text-primary-950 max-w-3/5',
       primary: 'bg-primary-500 text-neutral-50 max-w-2/3',
       disabled: 'bg-neutral-100 text-primary-950',
     },

--- a/apps/web/src/components/chat/index.ts
+++ b/apps/web/src/components/chat/index.ts
@@ -2,3 +2,6 @@ export { default as ChatInput } from './chat-input';
 export { default as ChatListItem } from './chat-list-item';
 export { default as ChatRoom } from './chat-room';
 export { default as ProductInfoCard } from './product-info-card';
+export { default as ChatBubble } from './chat-bubble';
+export { default as SentMessage } from './sent-message';
+export { default as ReceivedMessage } from './received-message';

--- a/apps/web/src/components/chat/received-message.tsx
+++ b/apps/web/src/components/chat/received-message.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useState } from 'react';
+
+import { ChatBubble } from '@/components/chat';
+import { ProfileImage } from '@/components/common';
+
+import { DONE_MESSAGE } from '@/constants/chat';
+import { dummyUrls } from '@/constants/dummy-urls';
+
+const ReceivedMessage = () => {
+  // TODO: 실시간 데이터 연동해서 상태값에 따라 bubble 달라질 수 있도록 수정하기
+  const [isDone, setIsDone] = useState(false);
+  const color = isDone ? 'disabled' : 'secondary';
+  const content = !isDone
+    ? 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.'
+    : DONE_MESSAGE;
+
+  const url = dummyUrls[0]!;
+
+  return (
+    <div className="flex justify-start gap-2 py-2">
+      <ProfileImage src={url} alt="content" className="size-10" />
+      <ChatBubble color={color} content={content} />
+      <p className="flex items-end text-xs font-light text-neutral-500">12:00 AM</p>
+    </div>
+  );
+};
+
+export default ReceivedMessage;

--- a/apps/web/src/components/chat/received-message.tsx
+++ b/apps/web/src/components/chat/received-message.tsx
@@ -12,9 +12,8 @@ const ReceivedMessage = () => {
   // TODO: 실시간 데이터 연동해서 상태값에 따라 bubble 달라질 수 있도록 수정하기
   const [isDone, setIsDone] = useState(false);
   const color = isDone ? 'disabled' : 'secondary';
-  const content = !isDone
-    ? 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.'
-    : DONE_MESSAGE;
+  const content = isDone ? DONE_MESSAGE : 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.';
+
 
   const url = dummyUrls[0]!;
 

--- a/apps/web/src/components/chat/sent-message.tsx
+++ b/apps/web/src/components/chat/sent-message.tsx
@@ -10,9 +10,8 @@ const SentMessage = () => {
   // TODO: 실시간 데이터 연동해서 상태값에 따라 bubble 달라질 수 있도록 수정하기
   const [isDone, setIsDone] = useState(false);
   const color = isDone ? 'disabled' : 'primary';
-  const content = !isDone
-    ? 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.'
-    : DONE_MESSAGE;
+  const content = isDone ? DONE_MESSAGE : 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.';
+
 
   const time = '12:00 AM';
 

--- a/apps/web/src/components/chat/sent-message.tsx
+++ b/apps/web/src/components/chat/sent-message.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useState } from 'react';
+
+import { ChatBubble } from '@/components/chat';
+
+import { DONE_MESSAGE } from '@/constants/chat';
+
+const SentMessage = () => {
+  // TODO: 실시간 데이터 연동해서 상태값에 따라 bubble 달라질 수 있도록 수정하기
+  const [isDone, setIsDone] = useState(false);
+  const color = isDone ? 'disabled' : 'primary';
+  const content = !isDone
+    ? 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.'
+    : DONE_MESSAGE;
+
+  const time = '12:00 AM';
+
+  return (
+    <div className="flex justify-end gap-2 py-2">
+      <p className="flex items-end text-xs font-light text-neutral-500">{time}</p>
+      <ChatBubble color={color} content={content} />
+    </div>
+  );
+};
+
+export default SentMessage;

--- a/apps/web/src/components/common/profile/image.tsx
+++ b/apps/web/src/components/common/profile/image.tsx
@@ -8,8 +8,8 @@ interface ProfileImageProps {
 
 const ProfileImage = ({ src, alt, className }: ProfileImageProps) => {
   return (
-    <Avatar>
-      <AvatarImage src={src} alt={alt} className={`object-cover ${className}`} />
+    <Avatar className={className}>
+      <AvatarImage src={src} alt={alt} className="object-cover" />
     </Avatar>
   );
 };

--- a/apps/web/src/lib/constants/chat.ts
+++ b/apps/web/src/lib/constants/chat.ts
@@ -1,3 +1,5 @@
+export const DONE_MESSAGE = '거래가 종료되어 확인할 수 없습니다.';
+
 export const CHAT_STATUS: { id: string; name: string }[] = [
   {
     id: 'all',

--- a/packages/tailwind-config/shared-styles.css
+++ b/packages/tailwind-config/shared-styles.css
@@ -46,6 +46,7 @@ h6 {
   --color-primary-600: #4238f1;
   --color-primary-700: #372ecf;
   --color-primary-800: #2e29a0;
+  --color-primary-950: #16214A;
 
   /* Success Colors */
   --color-success-50: #f0fdfa;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
closes #139 

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 
<img width="379" height="273" alt="스크린샷 2025-07-17 오후 4 28 26" src="https://github.com/user-attachments/assets/827bcf4a-c681-4ebb-a440-10be1cdc0c4f" />
<img width="377" height="207" alt="스크린샷 2025-07-17 오후 4 31 14" src="https://github.com/user-attachments/assets/2683b426-8bb2-4ca0-9b7b-c2c50c0de401" />


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

채팅방 메시지 컴포넌트를 스타일이 적용된 버블, 보내고 받은 메시지 레이아웃, 관련 상수 및 내보내기 업데이트로 구현합니다.

새로운 기능:
- 채팅 메시지 스타일링을 위한 색상 변형이 있는 ChatBubble 컴포넌트 추가
- 타임스탬프와 함께 채팅 레이아웃을 표시하는 SentMessage 및 ReceivedMessage 컴포넌트 생성
- 채팅 컴포넌트 인덱스에서 ChatBubble, SentMessage 및 ReceivedMessage 내보내기
- 완료된 트랜잭션을 위한 DONE_MESSAGE 상수 도입

개선 사항:
- ProfileImage를 업데이트하여 className을 이미지 대신 Avatar wrapper에 전달

빌드:
- 새로운 --color-primary-950 음영으로 Tailwind 구성 확장

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement chatroom message components with styled bubbles, layout for sent and received messages, and related constant and export updates.

New Features:
- Add ChatBubble component with color variants for chat message styling
- Create SentMessage and ReceivedMessage components displaying chat layouts with timestamps
- Export ChatBubble, SentMessage, and ReceivedMessage in the chat component index
- Introduce DONE_MESSAGE constant for completed transactions

Enhancements:
- Update ProfileImage to pass className to the Avatar wrapper instead of the image

Build:
- Extend Tailwind config with a new --color-primary-950 shade

</details>