### PR TITLE
[feat] 주소 정보 컴포넌트 제작 

### DIFF
--- a/apps/web/src/components/personal-info/address.tsx
+++ b/apps/web/src/components/personal-info/address.tsx
@@ -1,0 +1,46 @@
+import { tv } from 'tailwind-variants';
+
+import { BadgePrimary } from '@/components/personal-info';
+
+const style = tv({
+  base: 'flex items-center justify-between rounded-xl p-3',
+  variants: {
+    color: {
+      default: 'bg-white',
+      selected: 'bg-primary-50/70',
+    },
+  },
+});
+
+interface AddressProps {
+  color?: 'default' | 'selected';
+  children: React.ReactNode;
+  address: Address;
+}
+
+export interface Address {
+  name: string;
+  address: string;
+  phone: string;
+  isPrimary: boolean;
+}
+
+const Address = ({ color, children, address }: AddressProps) => {
+  return (
+    <div className={style({ color })}>
+      <div className="flex-col">
+        <div className="flex items-center gap-2">
+          <p className="text-lg font-medium text-neutral-900">{address.name}</p>
+          {address.isPrimary && <BadgePrimary />}
+        </div>
+        <div className="text-sm font-medium">
+          <p className="text-neutral-900">{address.address}</p>
+          <p className="text-neutral-500">{address.phone}</p>
+        </div>
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+};
+
+export default Address;

--- a/apps/web/src/components/personal-info/address.tsx
+++ b/apps/web/src/components/personal-info/address.tsx
@@ -28,7 +28,7 @@ export interface Address {
 const Address = ({ color, children, address }: AddressProps) => {
   return (
     <div className={style({ color })}>
-      <div className="flex-col">
+      <div className="flex flex-col">
         <div className="flex items-center gap-2">
           <p className="text-lg font-medium text-neutral-900">{address.name}</p>
           {address.isPrimary && <BadgePrimary />}

--- a/apps/web/src/components/personal-info/badge-primary.tsx
+++ b/apps/web/src/components/personal-info/badge-primary.tsx
@@ -1,0 +1,9 @@
+const BadgePrimary = () => {
+  return (
+    <div className="bg-primary-500 inline-flex h-6 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-md px-2 py-0 text-xs font-medium text-neutral-50 transition-[color,box-shadow]">
+      기본
+    </div>
+  );
+};
+
+export default BadgePrimary;

--- a/apps/web/src/components/personal-info/button-box.tsx
+++ b/apps/web/src/components/personal-info/button-box.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { Pencil, Trash2 } from 'lucide-react';
+
+import { Button } from '@/components/ui';
+
+const ButtonBox = () => {
+  // TODO: full-page 모달 연결
+  const handleEdit = () => {};
+  const handleDelete = () => {};
+
+  return (
+    <div className="flex">
+      <Button variant="solid" color="transparent" size="sm" onClick={handleEdit}>
+        <Pencil className="text-neutral-600" />
+      </Button>
+      <Button variant="solid" color="transparent" size="sm" onClick={handleDelete}>
+        <Trash2 className="text-neutral-600" />
+      </Button>
+    </div>
+  );
+};
+
+export default ButtonBox;

--- a/apps/web/src/components/personal-info/button-select.tsx
+++ b/apps/web/src/components/personal-info/button-select.tsx
@@ -10,7 +10,13 @@ const ButtonSelect = ({ isSelected }: ButtonSelectProps) => {
   const textColor = isSelected ? 'text-primary-500' : 'text-neutral-400';
 
   return (
-    <Button variant="solid" color="transparent" size="sm" aria-pressed={isSelected}>
+    <Button
+      variant="solid"
+      color="transparent"
+      size="sm"
+      aria-label={isSelected ? 'Deselect' : 'Select'}
+      aria-pressed={isSelected}
+    >
       <Check className={textColor} strokeWidth={2.5} />
     </Button>
   );

--- a/apps/web/src/components/personal-info/button-select.tsx
+++ b/apps/web/src/components/personal-info/button-select.tsx
@@ -1,0 +1,19 @@
+import { Check } from 'lucide-react';
+
+import { Button } from '@/components/ui';
+
+interface ButtonSelectProps {
+  isSelected: boolean;
+}
+
+const ButtonSelect = ({ isSelected }: ButtonSelectProps) => {
+  const textColor = isSelected ? 'text-primary-500' : 'text-neutral-400';
+
+  return (
+    <Button variant="solid" color="transparent" size="sm" aria-pressed={isSelected}>
+      <Check className={textColor} strokeWidth={2.5} />
+    </Button>
+  );
+};
+
+export default ButtonSelect;

--- a/apps/web/src/components/personal-info/index.ts
+++ b/apps/web/src/components/personal-info/index.ts
@@ -1,0 +1,4 @@
+export { default as AddressItem } from './address';
+export { default as BadgePrimary } from './badge-primary';
+export { default as ButtonBox } from './button-box';
+export { default as ButtonSelect } from './button-select';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안


## 📋 작업 내용
closes #276

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 
<img width="455" height="368" alt="스크린샷 2025-07-17 오후 7 35 01" src="https://github.com/user-attachments/assets/a40e5049-4613-406e-abe8-0cebcb0f93d3" />


## 📄 기타

## Sourcery 요약

주소 관리 및 표시를 위한 개인 정보 UI 컴포넌트 모음(AddressItem, BadgePrimary, ButtonBox, ButtonSelect, index 내보내기 포함)을 추가합니다.

새로운 기능:
- AddressItem 컴포넌트를 도입하여 기본 배지와 함께 사용자 주소 세부 정보를 렌더링합니다.
- 기본 주소를 나타내는 BadgePrimary 컴포넌트를 추가합니다.
- 편집 및 삭제 버튼이 있는 ButtonBox 컴포넌트를 추가합니다.
- 주소 선택을 전환하는 ButtonSelect 컴포넌트를 추가합니다.
- 개인 정보 컴포넌트를 위한 index barrel 내보내기를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a suite of personal-info UI components for managing and displaying addresses, including AddressItem, BadgePrimary, ButtonBox, ButtonSelect, and an index export.

New Features:
- Introduce AddressItem component to render user address details with primary badge
- Add BadgePrimary component for indicating primary addresses
- Add ButtonBox component with edit and delete buttons
- Add ButtonSelect component for toggling address selection
- Add index barrel export for personal-info components

</details>