### PR TITLE
[feat] 타임존 동기화 로직 추가

### DIFF
--- a/apps/docs/stories/Bage.stories.tsx
+++ b/apps/docs/stories/Bage.stories.tsx
@@ -1,5 +1,5 @@
-import Badge from '@repo/ui/components/common/Badge';
-import type { StoryObj, Meta } from '@storybook/nextjs';
+import Badge from '@repo/ui/components/Badge';
+import type { Meta, StoryObj } from '@storybook/nextjs';
 
 export default {
   component: Badge,

--- a/apps/docs/stories/Button.stories.tsx
+++ b/apps/docs/stories/Button.stories.tsx
@@ -1,5 +1,5 @@
-import Button from '@repo/ui/components/common/Button';
-import type { StoryObj, Meta } from '@storybook/nextjs';
+import Button from '@repo/ui/components/Button';
+import type { Meta, StoryObj } from '@storybook/nextjs';
 
 export default {
   component: Button,

--- a/apps/web/src/components/auction-detail/container.tsx
+++ b/apps/web/src/components/auction-detail/container.tsx
@@ -105,6 +105,8 @@ const AuctionDetailContainer = () => {
 
   return (
     <>
+      {/* // 개발 환경에서만 표시 */}
+      {/* {process.env.NODE_ENV === 'development' && <TimezoneTest />} */}
       <article className={cn(`flex flex-col items-center break-keep bg-neutral-100`, sectionStyle)}>
         <ItemImages urls={images} />
         <ProfileCard

--- a/apps/web/src/components/auction-detail/item-summary.tsx
+++ b/apps/web/src/components/auction-detail/item-summary.tsx
@@ -3,7 +3,7 @@ import { Badge } from '@/components/ui/badge';
 
 import useCountdown from '@/hooks/common/useCountdown';
 
-import { formatDate } from '@/lib/utils/date';
+import { convertToKST } from '@/lib/utils/date';
 
 interface ItemInformationProps {
   item: Item;
@@ -18,9 +18,9 @@ export interface Item {
 }
 
 const ItemSummary = ({ item, id }: ItemInformationProps) => {
-  const deadline = formatDate(new Date(item.endTime));
+  const deadline = convertToKST(item.endTime); // KST로 변환된 마감 시간
 
-  // 실시간으로 경매 종료 여부 확인
+  // 실시간으로 경매 종료 여부 확인: UTC 원본으로 카운트다운
   const { isExpired } = useCountdown(new Date(item.endTime));
 
   // 실제 경매 상태 결정 (서버 상태 + 실시간 시간 비교)

--- a/apps/web/src/lib/utils/date.ts
+++ b/apps/web/src/lib/utils/date.ts
@@ -51,3 +51,38 @@ export const convertHoursToTimestamp = (hours: string): string => {
   const added = new Date(now.getTime() + parseInt(hours, 10) * 60 * 60 * 1000);
   return added.toISOString();
 };
+
+// UTC 날짜를 KST로 변환하는 함수
+export const convertToKST = (utcDate: string | Date) => {
+  const date = new Date(utcDate);
+  return new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).format(date);
+};
+
+// KST 날짜 포맷팅 함수
+export const formatKSTDate = (utcDate: string | Date) => {
+  const date = new Date(utcDate);
+  return new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(date);
+};
+
+// KST 시간만 포맷팅하는 함수
+export const formatKSTTime = (utcDate: string | Date) => {
+  const date = new Date(utcDate);
+  return new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
closes #326 
## 📋 작업 내용

UTC → KST 변환 로직

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

새로운 변환 및 포맷팅 유틸리티를 추가하고, 이를 경매 마감일 표시에 적용하며, 관련 스토리 임포트를 업데이트하여 KST 시간대 동기화를 도입합니다.

새로운 기능:
- KST 시간대 변환 및 포맷팅을 위한 `convertToKST`, `formatKSTDate`, `formatKSTTime` 유틸리티 함수를 추가합니다.

개선 사항:
- 카운트다운 로직에는 UTC를 유지하면서 `convertToKST`를 사용하여 경매 마감일을 KST로 표시합니다.
- `Badge` 및 `Button`에 대한 Storybook 스토리가 간소화된 임포트 경로를 사용하도록 업데이트합니다.

기타 작업:
- `AuctionDetailContainer`에 주석 처리된 개발 전용 `TimezoneTest` 컴포넌트를 삽입합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce KST timezone synchronization by adding new conversion and formatting utilities, applying them to auction deadline displays, and updating related story imports.

New Features:
- Add convertToKST, formatKSTDate, and formatKSTTime utility functions for KST timezone conversion and formatting.

Enhancements:
- Display auction deadline in KST using convertToKST while retaining UTC for the countdown logic.
- Update Storybook stories for Badge and Button to use simplified import paths.

Chores:
- Insert a commented development-only TimezoneTest component in AuctionDetailContainer.

</details>