### PR TITLE
Feat/create itemimg upload #332

### DIFF
--- a/apps/web/src/components/auction-edit/form-edit.tsx
+++ b/apps/web/src/components/auction-edit/form-edit.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import CreateAuctionForm from '@/components/auction-create/form-create';
-import useEditAuction from '@/hooks/auction/useEditAuction';
 import { Button } from '@/components/ui';
+
+import useEditAuction from '@/hooks/auction/useEditAuction';
 
 interface FormEditProps {
   itemId: string;

--- a/apps/web/src/hooks/auction/useCreateAuction.tsx
+++ b/apps/web/src/hooks/auction/useCreateAuction.tsx
@@ -12,7 +12,7 @@ const useCreateAuction = () => {
   const [errors, setErrors] = useState<FormErrorMessageType>({});
   // 에러 메시지 상태를 객체 형태로 보관
   const [files, setFiles] = useState<File[]>([]);
-  // const [userId, setUserId] = useState('de35f43a-138c-4690-ba5e-9372cb943cd2');
+  const [isPending, setIsPending] = useState(false);
 
   const router = useRouter(); // Next.js router 추가
 
@@ -20,67 +20,71 @@ const useCreateAuction = () => {
     async (e: React.FormEvent<HTMLFormElement>) => {
       e.preventDefault();
 
-      const form = e.currentTarget;
-      const formData = new FormData(form);
-      const newErrors: FormErrorMessageType = {};
+      if (isPending) return; // 이미 진행 중이면 리턴
 
-      //로그인된 사용자 ID 가져오기
-      const supabase = createClient();
-      const {
-        data: { user },
-        error: userError,
-      } = await supabase.auth.getUser();
-
-      if (userError || !user) {
-        setErrors({ server: '로그인이 필요합니다. 다시 로그인해주세요.' });
-        return;
-      }
-
-      // FormData → rawData 변환
-      const rawData = {
-        title: String(formData.get('title') ?? ''),
-        description: String(formData.get('description') ?? ''),
-        category_id: String(formData.get('category_id') ?? ''),
-        prices: {
-          start_price: Number(formData.get('start_price') ?? 0),
-          min_bid_unit: Number(formData.get('min_bid_unit') ?? 0),
-        },
-        end_time: String(formData.get('end_time') ?? ''),
-        // images: [],
-      };
-
-      // Zod 유효성 검사
-      const result = createAuctionSchema.safeParse(rawData);
-
-      //이미지 등록 여부 확인
-      // if (files.length <= 0) {
-      //   newErrors.images = '이미지를 꼭 한 장 이상 등록해주세요.';
-      // }
-
-      if (!result.success) {
-        console.log('유효성 검사 실패');
-        const zodErrors: FormErrorMessageType = {};
-        for (const issue of result.error.errors) {
-          const path = issue.path.join('.');
-          zodErrors[path] = issue.message;
-        }
-        // 이미지 에러(newErrors)와 합쳐서 set
-        setErrors({ ...newErrors, ...zodErrors });
-        return;
-      }
-
-      if (Object.keys(newErrors).length > 0) {
-        setErrors(newErrors);
-        return;
-      }
-
-      setErrors({});
-
-      const phasedData: CreateAuctionFormData = {
-        ...result.data,
-      };
+      setIsPending(true);
 
       try {
+        const form = e.currentTarget;
+        const formData = new FormData(form);
+        const newErrors: FormErrorMessageType = {};
+
+        //로그인된 사용자 ID 가져오기
+        const supabase = createClient();
+        const {
+          data: { user },
+          error: userError,
+        } = await supabase.auth.getUser();
+
+        if (userError || !user) {
+          setErrors({ server: '로그인이 필요합니다. 다시 로그인해주세요.' });
+          return; // 이제 finally에서 setIsPending(false) 실행됨
+        }
+
+        // FormData → rawData 변환
+        const rawData = {
+          title: String(formData.get('title') ?? ''),
+          description: String(formData.get('description') ?? ''),
+          category_id: String(formData.get('category_id') ?? ''),
+          prices: {
+            start_price: Number(formData.get('start_price') ?? 0),
+            min_bid_unit: Number(formData.get('min_bid_unit') ?? 0),
+          },
+          end_time: String(formData.get('end_time') ?? ''),
+        };
+
+        // Zod 유효성 검사
+        const result = createAuctionSchema.safeParse(rawData);
+
+        //이미지 등록 여부 확인
+        if (files.length <= 0) {
+          newErrors.images = '이미지를 꼭 한 장 이상 등록해주세요.';
+        }
+
+        if (!result.success) {
+          console.log('유효성 검사 실패');
+          const zodErrors: FormErrorMessageType = {};
+          for (const issue of result.error.errors) {
+            const path = issue.path.join('.');
+            zodErrors[path] = issue.message;
+          }
+          // 이미지 에러(newErrors)와 합쳐서 set
+          setErrors({ ...newErrors, ...zodErrors });
+          return; // 이제 finally에서 setIsPending(false) 실행됨
+        }
+
+        if (Object.keys(newErrors).length > 0) {
+          setErrors(newErrors);
+          return; // 이제 finally에서 setIsPending(false) 실행됨
+        }
+
+        setErrors({});
+
+        const phasedData: CreateAuctionFormData = {
+          ...result.data,
+        };
+
+        // try 블록 제거 (이미 위에서 시작)
         // 1. 먼저 경매 등록 (auctionId 받기)
         const phasedDataWithoutImages = {
           ...phasedData,
@@ -110,13 +114,18 @@ const useCreateAuction = () => {
 
         router.push(`/auction/${auctionId}`);
       } catch (error) {
+        // catch 블록 추가
+        console.error('❌ 경매 등록 에러:', error); // 콘솔 로그 추가
         setErrors({ server: '경매 등록 중 오류가 발생했습니다. 다시 시도해주세요.' });
+      } finally {
+        // finally 블록 추가
+        setIsPending(false); // 모든 경우에 pending 상태 해제
       }
     },
-    [files, router]
+    [files, router, isPending]
   );
 
-  return { errors, handleSubmit, setFiles };
+  return { errors, handleSubmit, setFiles, isPending };
 };
 
 export default useCreateAuction;

--- a/apps/web/src/hooks/auction/useDeletePreview.tsx
+++ b/apps/web/src/hooks/auction/useDeletePreview.tsx
@@ -13,7 +13,13 @@ const deletePreviewImage = ({
   setFiles,
   index,
 }: DeletePreviewImageProps) => {
+  // 프리뷰 이미지에서 해당 인덱스 제거
   setPreviewImages((prev) => prev.filter((_, i) => i !== index));
+
+  // 파일 배열에서도 해당 인덱스 제거
+  setFiles((prev) => prev.filter((_, i) => i !== index));
+
+  // 이미지 개수 감소
   setImgLength((prev) => prev - 1);
 };
 

--- a/apps/web/src/hooks/auction/useOnChangePreview.tsx
+++ b/apps/web/src/hooks/auction/useOnChangePreview.tsx
@@ -17,12 +17,30 @@ const useOnChagePreview =
       return;
     }
 
-    //미리보기 이미지 등록
-    const newUrls: string[] = imageFiles.map((file) => URL.createObjectURL(file));
+    // 현재 파일들과 새로 선택된 파일들을 합쳐서 8개 제한 적용
+    setFiles((prev) => {
+      const combinedFiles = [...prev, ...imageFiles];
 
-    setPreviewImages((prev) => [...prev, ...newUrls]);
-    setImgLength((prev) => prev + newUrls.length);
-    setFiles((prev) => [...prev, ...imageFiles]);
+      if (combinedFiles.length > 8) {
+        alert('이미지는 최대 8개까지 등록할 수 있습니다.');
+        // 8개까지만 잘라서 반환
+        const limitedFiles = combinedFiles.slice(0, 8);
+
+        // 프리뷰도 동일하게 8개로 제한
+        const newUrls = limitedFiles.slice(prev.length).map((file) => URL.createObjectURL(file));
+        setPreviewImages((prevImages) => [...prevImages, ...newUrls]);
+        setImgLength(8);
+
+        return limitedFiles;
+      }
+
+      // 8개 이하인 경우 정상 처리
+      const newUrls = imageFiles.map((file) => URL.createObjectURL(file));
+      setPreviewImages((prevImages) => [...prevImages, ...newUrls]);
+      setImgLength(prev.length + imageFiles.length);
+
+      return combinedFiles;
+    });
 
     e.target.value = '';
   };

--- a/apps/web/src/hooks/auction/useOnChangePreview.tsx
+++ b/apps/web/src/hooks/auction/useOnChangePreview.tsx
@@ -1,48 +1,54 @@
-import { SetStateAction } from 'react';
+import { SetStateAction, useCallback } from 'react';
 
-const useOnChagePreview =
-  (
-    setImgLength: React.Dispatch<SetStateAction<number>>,
-    setPreviewImages: React.Dispatch<SetStateAction<string[]>>,
-    setFiles: React.Dispatch<SetStateAction<File[]>>
-  ) =>
-  (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { files } = e.target;
-    if (!files) return;
+const useOnChagePreview = (
+  setImgLength: React.Dispatch<SetStateAction<number>>,
+  setPreviewImages: React.Dispatch<SetStateAction<string[]>>,
+  setFiles: React.Dispatch<SetStateAction<File[]>>
+) => {
+  return useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const { files } = e.target;
+      if (!files) return;
 
-    const imageFiles = Array.from(files).filter((file) => file.type.startsWith('image/'));
-    if (imageFiles.length === 0) {
-      alert('이미지 파일만 등록할 수 있습니다.');
-      e.target.value = '';
-      return;
-    }
-
-    // 현재 파일들과 새로 선택된 파일들을 합쳐서 8개 제한 적용
-    setFiles((prev) => {
-      const combinedFiles = [...prev, ...imageFiles];
-
-      if (combinedFiles.length > 8) {
-        alert('이미지는 최대 8개까지 등록할 수 있습니다.');
-        // 8개까지만 잘라서 반환
-        const limitedFiles = combinedFiles.slice(0, 8);
-
-        // 프리뷰도 동일하게 8개로 제한
-        const newUrls = limitedFiles.slice(prev.length).map((file) => URL.createObjectURL(file));
-        setPreviewImages((prevImages) => [...prevImages, ...newUrls]);
-        setImgLength(8);
-
-        return limitedFiles;
+      const imageFiles = Array.from(files).filter((file) => file.type.startsWith('image/'));
+      if (imageFiles.length === 0) {
+        alert('이미지 파일만 등록할 수 있습니다.');
+        e.target.value = '';
+        return;
       }
 
-      // 8개 이하인 경우 정상 처리
-      const newUrls = imageFiles.map((file) => URL.createObjectURL(file));
-      setPreviewImages((prevImages) => [...prevImages, ...newUrls]);
-      setImgLength(prev.length + imageFiles.length);
+      // 현재 파일 개수 확인을 위한 함수
+      setFiles((prevFiles) => {
+        const combinedFiles = [...prevFiles, ...imageFiles];
+        const currentLength = prevFiles.length;
 
-      return combinedFiles;
-    });
+        if (combinedFiles.length > 8) {
+          alert('이미지는 최대 8개까지 등록할 수 있습니다.');
+          const limitedFiles = combinedFiles.slice(0, 8);
+          const actualNewFiles = limitedFiles.slice(currentLength);
 
-    e.target.value = '';
-  };
+          // 새로운 파일들만 프리뷰 생성
+          const newUrls = actualNewFiles.map((file) => URL.createObjectURL(file));
+
+          // 별도로 프리뷰와 길이 업데이트
+          setPreviewImages((prev) => [...prev, ...newUrls]);
+          setImgLength(8);
+
+          return limitedFiles;
+        }
+
+        // 정상 케이스
+        const newUrls = imageFiles.map((file) => URL.createObjectURL(file));
+        setPreviewImages((prev) => [...prev, ...newUrls]);
+        setImgLength(currentLength + imageFiles.length);
+
+        return combinedFiles;
+      });
+
+      e.target.value = '';
+    },
+    [setImgLength, setPreviewImages, setFiles]
+  );
+};
 
 export default useOnChagePreview;

--- a/apps/web/src/views/CreateAcutionPage.tsx
+++ b/apps/web/src/views/CreateAcutionPage.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui';
 import useCreateAuction from '@/hooks/auction/useCreateAuction';
 
 const CreateAuctionPage = () => {
-  const { handleSubmit, errors, setFiles } = useCreateAuction();
+  const { handleSubmit, errors, setFiles, isPending } = useCreateAuction();
 
   return (
     <form onSubmit={handleSubmit} className="relative mt-2.5">
@@ -25,8 +25,8 @@ const CreateAuctionPage = () => {
 
       <section className="backdrop-blur-xs from-white-0 sticky bottom-0 bg-white/70 px-[15px] pb-9 pt-4">
         {/* 모바일 home indicator 계산 배포 환경에서 확인 필요: pb-[env(safe-area-inset-bottom)] */}
-        <Button className="w-full" size={'lg'}>
-          등록하기
+        <Button className="w-full" size={'lg'} disabled={isPending} type="submit">
+          {isPending ? '등록 중...' : '등록하기'}
         </Button>
       </section>
     </form>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
closes #332 
## 📋 작업 내용

새로운 기능
- 등록 버튼 로딩 상태 추가: 등록 버튼 클릭 시 "등록 중..." 표시로 사용자 경험 개선

버그 수정
1. 이미지 업로드 제한 로직 개선

- 8개 제한 로직 통일: 파일 배열과 프리뷰 배열에서 동일하게 8개 제한 적용
- 정확한 슬라이싱: combinedFiles.slice(0, 8)로 정확히 8개까지만 유지

2. 이미지 삭제 기능 수정

- 파일 동기화 문제 해결: 이미지 삭제 후 setFiles에서 파일이 제대로 제거되지 않던 문제 수정
- 스토리지 업로드 오류 방지: 삭제된 이미지까지 포함해서 업로드되던 문제 해결

3. React 렌더링 경고 해결

- 상태 업데이트 최적화: setFiles 내부에서 다른 state 업데이트하지 않도록 분리
- useCallback 활용: 함수 메모이제이션으로 안정적인 비동기 처리
- 렌더링 사이클 충돌 방지: 컴포넌트 렌더링 중 다른 컴포넌트 state 업데이트 문제 해결

4. Alert 중복 표시 문제 해결

- useRef 활용: alertShownRef로 alert 중복 방지 로직 구현
- 1초 제한: alert이 1초 동안 한 번만 표시되도록 제한
- 조건 확인 후 처리: 미리 계산해서 조건에 따라 처리하도록 개선

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
