### PR TITLE
[feature] 채팅 목록 호출 api 작성 및 연결

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { prisma } from '@repo/db';
+
+import { createClient } from '@/lib/supabase/server';
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    // 현재 사용자 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        {
+          error: '로그인이 필요합니다.',
+          message: 'Authentication required',
+        },
+        { status: 401 }
+      );
+    }
+
+    console.log('현재 사용자:', user.id);
+
+    // 사용자가 참여한 채팅방들 조회
+    const chatRooms = await prisma.chatRoom.findMany({
+      where: {
+        OR: [{ sellerId: user.id }, { buyerId: user.id }],
+        isDeleted: false,
+      },
+      include: {
+        // 경매 정보 포함
+        auction: {
+          select: {
+            id: true,
+            title: true,
+            thumbnailUrl: true,
+            status: true,
+          },
+        },
+        // 마지막 메시지 정보 (1개만)
+        messages: {
+          orderBy: { sentAt: 'desc' },
+          take: 1,
+          select: {
+            id: true,
+            content: true,
+            sentAt: true,
+            senderId: true,
+          },
+        },
+        // 상대방 정보 (판매자/구매자)
+        seller: {
+          select: {
+            id: true,
+            nickname: true,
+            profileImg: true,
+          },
+        },
+        buyer: {
+          select: {
+            id: true,
+            nickname: true,
+            profileImg: true,
+          },
+        },
+      },
+      orderBy: {
+        lastMessageAt: 'desc', // 최근 메시지 순
+      },
+    });
+
+    // 상대방 정보 추가
+    const chatRoomsWithOtherUser = chatRooms.map((room) => ({
+      ...room,
+      // 상대방 정보 결정 (현재 사용자가 아닌 쪽)
+      otherUser: user.id === room.sellerId ? room.buyer : room.seller,
+    }));
+
+    console.log(`성공: ${chatRoomsWithOtherUser.length}개 채팅방 반환`);
+
+    return NextResponse.json({
+      data: chatRoomsWithOtherUser,
+      total: chatRoomsWithOtherUser.length,
+    });
+  } catch (error) {
+    console.error('채팅방 목록 조회 에러:', error);
+    return NextResponse.json(
+      {
+        error: 'Internal server error',
+        details: error instanceof Error ? error.message : 'Unknown error',
+        message: '채팅방 목록을 불러오는 중 오류가 발생했습니다.',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -1,13 +1,44 @@
-import { ChatListItem } from '@/components/chat';
+'use client';
+
+import { ChatListCard } from '@/components/chat';
 import { FilterTab } from '@/components/common';
+
+import { useChatRooms } from '@/hooks/chat/useChatRoom';
 
 import { CHAT_STATUS } from '@/lib/constants/chat';
 
 const Page = () => {
+  const { chatRooms, isLoading, error, total } = useChatRooms();
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <div className="text-gray-500">채팅방 목록을 불러오는 중...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <div className="text-red-500">채팅방 목록을 불러오는데 실패했습니다</div>
+      </div>
+    );
+  }
+  if (!chatRooms.length) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <div className="text-gray-500">대화 중인 채팅방이 없습니다</div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex h-full w-full flex-col px-4">
       <FilterTab filterKey={'chatStatus'} items={CHAT_STATUS} />
-      <ChatListItem />
+      {chatRooms.map((chat) => {
+        return <ChatListCard key={chat.id} chatInfo={chat} />;
+      })}
     </div>
   );
 };

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -21,7 +21,7 @@ const Page = () => {
   if (error) {
     return (
       <div className="flex items-center justify-center py-8">
-        <div className="text-red-500">채팅방 목록을 불러오는데 실패했습니다</div>
+        <div className="text-gray-500">채팅방 목록을 불러오는데 실패했습니다</div>
       </div>
     );
   }

--- a/apps/web/src/components/chat/button-chat-more.tsx
+++ b/apps/web/src/components/chat/button-chat-more.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useParams, useRouter } from 'next/navigation';
+
+import { ButtonMore } from '@/components/common';
+
+import { ButtonMoreItem } from '../common/button/more';
+
+const ButtonChatMore = () => {
+  const params = useParams();
+  const router = useRouter();
+
+  const chatId = params?.id as string;
+
+  const handleDelete = async () => {
+    try {
+      // 삭제 api 추가
+      alert('채팅이 삭제되었습니다!');
+    } catch (error) {
+      alert('삭제 중 오류 발생!');
+      console.error(error);
+    }
+  };
+
+  const AUCTION_DETAILS: ButtonMoreItem[] = [
+    { id: 'delete', title: '삭제하기', onClick: handleDelete },
+    // 신고하기 게시판 route로 이동
+    { id: 'report', title: '신고하기', onClick: () => router.push(`/`) },
+  ];
+
+  return <ButtonMore items={AUCTION_DETAILS} />;
+};
+
+export default ButtonChatMore;

--- a/apps/web/src/components/chat/chat-list-card.tsx
+++ b/apps/web/src/components/chat/chat-list-card.tsx
@@ -10,8 +10,13 @@ import Thumbnail from '@/components/ui/thumbnail';
 import { PREVIEWCHATS } from '@/lib/constants/chat';
 import { dummyUrls } from '@/lib/constants/dummy-urls';
 
-const ChatListItem = () => {
+import { ChatRoom } from '@/types/chat';
+
+const ChatListCard = ({ chatInfo }: { chatInfo: ChatRoom }) => {
   const lastMessageTime = PREVIEWCHATS[9]!.last_message_at;
+  console.log(chatInfo);
+
+  const { auction, otherUser, lastMessageAt, messages } = chatInfo;
 
   const msgElapsed = () => {
     const lastTime = new Date(lastMessageTime).getTime();
@@ -27,22 +32,26 @@ const ChatListItem = () => {
     const oneMonth = 28 * oneDay;
 
     if (gapMs < oneHour) {
+      // 방금
+      // n분 전
       const minutes = Math.floor(gapMs / oneMinute);
       return `${minutes}min`;
     } else if (gapMs < oneDay) {
+      //1시간 전
       const hours = Math.floor(gapMs / oneHour);
       return `${hours}${hours === 1 ? 'hour' : 'hours'}`;
     } else if (gapMs < oneWeek) {
+      //n일 전
       const days = Math.floor(gapMs / oneDay);
       return `${days}${days === 1 ? 'day' : 'days'}`;
     } else {
+      // n달 전
+      // n년 전
       return '일주일 초과';
     }
   };
 
-  const test = msgElapsed();
-
-  console.log(test);
+  // const test = msgElapsed();
 
   // TODO: 기능 연결 시 roomId 로 연결 해서 해당 태그 내에서 작성할 것.
   const roomId = '123';
@@ -69,4 +78,4 @@ const ChatListItem = () => {
   );
 };
 
-export default ChatListItem;
+export default ChatListCard;

--- a/apps/web/src/components/chat/chat-list-card.tsx
+++ b/apps/web/src/components/chat/chat-list-card.tsx
@@ -2,9 +2,7 @@
 
 import Link from 'next/link';
 
-import { EllipsisVertical } from 'lucide-react';
-
-import { Button } from '@/components/ui/button';
+import ButtonChatMore from '@/components/chat/button-chat-more';
 import Thumbnail from '@/components/ui/thumbnail';
 
 import { ChatRoom } from '@/types/chat';
@@ -79,9 +77,7 @@ const ChatListCard = ({ chatInfo }: { chatInfo: ChatRoom }) => {
           </p>
         </div>
       </Link>
-      <Button color="transparent" className="h-10 w-10">
-        <EllipsisVertical />
-      </Button>
+      <ButtonChatMore />
     </div>
   );
 };

--- a/apps/web/src/components/chat/chat-list-card.tsx
+++ b/apps/web/src/components/chat/chat-list-card.tsx
@@ -7,19 +7,14 @@ import { EllipsisVertical } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import Thumbnail from '@/components/ui/thumbnail';
 
-import { PREVIEWCHATS } from '@/lib/constants/chat';
-import { dummyUrls } from '@/lib/constants/dummy-urls';
-
 import { ChatRoom } from '@/types/chat';
 
 const ChatListCard = ({ chatInfo }: { chatInfo: ChatRoom }) => {
-  const lastMessageTime = PREVIEWCHATS[9]!.last_message_at;
-  console.log(chatInfo);
-
   const { auction, otherUser, lastMessageAt, messages } = chatInfo;
 
   const msgElapsed = () => {
-    const lastTime = new Date(lastMessageTime).getTime();
+    if (!lastMessageAt) return '';
+    const lastTime = new Date(lastMessageAt).getTime();
     const now = Date.now();
     const gapMs = now - lastTime;
 
@@ -27,48 +22,61 @@ const ChatListCard = ({ chatInfo }: { chatInfo: ChatRoom }) => {
     const oneHour = 60 * oneMinute;
     const oneDay = 24 * oneHour;
     const oneWeek = 7 * oneDay;
-    const twoWeek = 14 * oneDay;
-    const threeWeek = 21 * oneDay;
     const oneMonth = 28 * oneDay;
+    const oneYear = 365 * oneDay;
 
-    if (gapMs < oneHour) {
+    if (gapMs < oneMinute) {
       // 방금
+      return '방금';
+    } else if (gapMs < oneHour) {
       // n분 전
       const minutes = Math.floor(gapMs / oneMinute);
-      return `${minutes}min`;
+      return `${minutes}분 전`;
     } else if (gapMs < oneDay) {
-      //1시간 전
+      // 1시간 전, n시간 전
       const hours = Math.floor(gapMs / oneHour);
-      return `${hours}${hours === 1 ? 'hour' : 'hours'}`;
+      return `${hours}시간 전`;
     } else if (gapMs < oneWeek) {
-      //n일 전
+      // n일 전
       const days = Math.floor(gapMs / oneDay);
-      return `${days}${days === 1 ? 'day' : 'days'}`;
-    } else {
+      return `${days}일 전`;
+    } else if (gapMs < oneMonth) {
+      // n주 전
+      const weeks = Math.floor(gapMs / oneWeek);
+      return `${weeks}주 전`;
+    } else if (gapMs < oneYear) {
       // n달 전
+      const months = Math.floor(gapMs / oneMonth);
+      return `${months}달 전`;
+    } else {
       // n년 전
-      return '일주일 초과';
+      const years = Math.floor(gapMs / oneYear);
+      return `${years}년 전`;
     }
   };
 
-  // const test = msgElapsed();
-
   // TODO: 기능 연결 시 roomId 로 연결 해서 해당 태그 내에서 작성할 것.
-  const roomId = '123';
+  const roomId = chatInfo.id;
   const link = `/chat/${roomId}`;
 
   return (
     <div className="flex h-fit w-full items-center justify-between gap-2.5">
       <Link href={link} className="flex w-full shrink items-center gap-2.5 py-1">
-        <Thumbnail url={dummyUrls[0]!} alt={'sample'} className="w-15 h-15 shrink-0" />
+        <Thumbnail
+          url={auction.thumbnailUrl as string}
+          alt={'sample'}
+          className="w-15 h-15 shrink-0"
+        />
         <div className="flex w-full shrink flex-col">
-          <div className="">
+          <div>
             <p className="flex gap-2">
-              <strong>{PREVIEWCHATS[0]!.opponent_nickname}</strong>
-              <span>{PREVIEWCHATS[0]!.last_message_at}</span>
+              <strong>{otherUser.nickname}</strong>
+              <span>{msgElapsed()}</span>
             </p>
           </div>
-          <p className="">{PREVIEWCHATS[0]!.last_message}</p>
+          <p className="line-clamp-1 min-h-6 flex-1">
+            {!messages.length ? '' : '마지막 메세지 보여주기'}
+          </p>
         </div>
       </Link>
       <Button color="transparent" className="h-10 w-10">

--- a/apps/web/src/components/chat/index.ts
+++ b/apps/web/src/components/chat/index.ts
@@ -11,7 +11,7 @@ export { default as ReceivedMessage } from './messages/received-message';
 export { default as DateMessage } from './messages/date-message';
 export { default as ChatContainer } from './messages/chat-container';
 
-export { default as ChatListItem } from './chat-list-item';
+export { default as ChatListCard } from './chat-list-card';
 export { default as TestChatRoom } from './test-chat-room';
 export { default as ProductInfoCard } from './product-info-card';
 

--- a/apps/web/src/components/common/profile/edit/form-edit.tsx
+++ b/apps/web/src/components/common/profile/edit/form-edit.tsx
@@ -1,4 +1,3 @@
-// apps/web/src/components/common/profile/edit/form-edit.tsx
 'use client';
 
 import { useEffect, useState } from 'react';
@@ -15,7 +14,7 @@ import ProfileImageUploader from './profile-image-uploader';
 
 const ProfileEditForm = () => {
   const { data: profile, isLoading } = useMyProfile(); // 프로필 데이터 가져오기
-  
+
   const { showToast } = useToastStore(); // 토스트 store
 
   const {
@@ -26,8 +25,6 @@ const ProfileEditForm = () => {
     error,
   } = useUpdateProfile();
 
-  const { mutate: updateProfileMutation, isPending } = useUpdateProfile();
-  
   const [nickname, setNickname] = useState<string>('');
   const [profileImage, setProfileImage] = useState<File | null>(null);
   const [nicknameError, setNicknameError] = useState<string>('');

--- a/apps/web/src/hooks/chat/useChatRoom.ts
+++ b/apps/web/src/hooks/chat/useChatRoom.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { getChatRooms } from '@/lib/api/chat';
+
+import { ChatRoom, ChatRoomsResponse } from '@/types/chat';
+
+export const CHAT_ROOMS_QUERY_KEY = ['chatRooms'];
+
+// 커스텀 훅 반환 타입
+interface UseChatRoomsReturn {
+  chatRooms: ChatRoom[];
+  total: number;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+export const useChatRooms = (): UseChatRoomsReturn => {
+  const query = useQuery<ChatRoomsResponse, Error>({
+    queryKey: CHAT_ROOMS_QUERY_KEY,
+    queryFn: getChatRooms,
+    staleTime: 1000 * 60 * 5, // 5분간 캐시 유지
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    chatRooms: query.data?.data || [],
+    total: query.data?.total || 0,
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+};

--- a/apps/web/src/lib/api/chat.ts
+++ b/apps/web/src/lib/api/chat.ts
@@ -1,0 +1,8 @@
+import apiClient from '@/lib/api/client';
+
+import { ChatRoomsResponse } from '@/types/chat';
+
+export const getChatRooms = async (): Promise<ChatRoomsResponse> => {
+  const response = await apiClient.get<ChatRoomsResponse>('/chat');
+  return response.data;
+};

--- a/apps/web/src/lib/types/chat.ts
+++ b/apps/web/src/lib/types/chat.ts
@@ -15,27 +15,32 @@ export interface ChatMessage {
 
 export interface ChatRoom {
   id: string;
-  auction_id: string;
-  seller_id: string;
-  buyer_id: string;
-  room_type: string;
-  created_at: string;
-  last_message_at: string | null;
-  is_deleted: boolean;
-  // 추가 정보
-  auction_item?: {
+  auctionId: string;
+  createdAt: string;
+  lastMessageAt: string | null;
+  isDeleted: boolean;
+  myRole: 'seller' | 'buyer';
+  otherUser: {
+    id: string;
+    nickname: string;
+  };
+  auction: {
     id: string;
     title: string;
-    thumbnail_url?: string;
+    thumbnailUrl: string | null;
+    status: string;
   };
-  seller?: {
+  messages: {
     id: string;
-    nickname: string;
-  };
-  buyer?: {
-    id: string;
-    nickname: string;
-  };
+    content: string;
+    sentAt: string;
+    senderId: string;
+  }[];
+}
+
+export interface ChatRoomsResponse {
+  data: ChatRoom[];
+  total: number;
 }
 
 export interface ChatUser {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #338 

## 📋 작업 내용

- 채팅 목록 데이터 호출 api 작성
- 채팅 목록 데이터 매핑 및 연결
- 더보기 버튼 생성 (기능연결X)
- 최근 메세지 송수신 날짜 계산 함수 수정
- 목록 스타일 추가 : 1줄만 보이기, 메세지가 없을 경우 높이값 유지

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

백엔드 API, 클라이언트 훅, 타입 업데이트 및 UI 컴포넌트를 추가하여 상대적 타임스탬프와 추가 작업이 있는 채팅 목록을 표시함으로써 종단 간 채팅방 목록 기능을 구현합니다.

새로운 기능:
- 사용자의 경매, 마지막 메시지, 참여자 데이터가 포함된 채팅방을 가져오는 `GET /api/chat` 엔드포인트를 추가했습니다.
- 클라이언트에서 채팅방을 검색할 수 있도록 `useChatRooms` 훅과 `getChatRooms` API 클라이언트를 구현했습니다.
- 채팅 페이지에 `ChatListCard` 컴포넌트를 사용하여 상대적 시간 표시 및 더보기 버튼 작업이 가능한 채팅방 목록을 렌더링합니다.

개선 사항:
- `ChatRoom` 타입 정의를 리팩토링하여 camelCase 필드를 사용하고, 경매 및 메시지 배열을 포함하며, `myRole`과 `otherUser`를 추가했습니다.
- 마지막 메시지에 대한 경과 시간 계산을 추가하고, 메시지가 없을 때 일관된 높이를 유지하는 한 줄 미리보기 스타일을 적용했습니다.
- 임시 삭제 및 신고 작업이 가능한 `ButtonChatMore` 컴포넌트를 도입했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement end-to-end chat rooms listing by adding a backend API, client hook, type updates, and UI components to display chat list with relative timestamps and more actions

New Features:
- Add GET /api/chat endpoint to fetch user's chat rooms with auction, last message, and participant data
- Implement useChatRooms hook and getChatRooms API client to retrieve chat rooms on the client
- Render chat rooms list in the chat page using ChatListCard component with relative time display and more-button actions

Enhancements:
- Refactor ChatRoom type definitions to use camelCase fields, embed auction and messages arrays, and include myRole and otherUser
- Add elapsed-time calculation for last message and apply one-line preview styling with consistent height when no messages
- Introduce ButtonChatMore component with placeholder delete and report actions

</details>