### PR TITLE
[Fix] 회원가입완료시 홈 네브바 안보이는 버그 해결

### DIFF
--- a/apps/web/src/components/layout/home-filter-select.tsx
+++ b/apps/web/src/components/layout/home-filter-select.tsx
@@ -135,7 +135,7 @@ const HomeFilterSelect = () => {
           })}
           <li>
             {/* /위치설정 페이지로 이동 */}
-            <Link href={'/'}>내 동네 설정</Link>
+            <Link href={'/location'}>내 동네 설정</Link>
           </li>
         </ul>
       </PopoverContent>

--- a/apps/web/src/components/location/search-location-picker.tsx
+++ b/apps/web/src/components/location/search-location-picker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { Map, X } from 'lucide-react';
 
@@ -28,8 +28,19 @@ const SearchLocationPicker = ({
   const [searchResults, setSearchResults] = useState<SearchResultItem[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
-
+  const [isSignupFlow, setIsSignupFlow] = useState(false);
   const { error, retry } = useGeolocation();
+
+  useEffect(() => {
+    const checkSignupFlow = () => {
+      if (typeof document !== 'undefined') {
+        const hasSignupFlowCookie = document.cookie.includes('signup-flow=active');
+        setIsSignupFlow(hasSignupFlowCookie);
+      }
+    };
+
+    checkSignupFlow();
+  }, []);
 
   const handleSearch = async () => {
     if (!searchTerm.trim()) return;
@@ -58,12 +69,16 @@ const SearchLocationPicker = ({
     <div className="flex h-full flex-col bg-white">
       {/* 헤더 */}
       <div className="flex items-center justify-between border-b border-neutral-200 p-4">
-        <button
-          onClick={onClose}
-          className="flex items-center gap-2 text-neutral-600 hover:text-neutral-900"
-        >
-          <X className="h-5 w-5" />
-        </button>
+        {!isSignupFlow ? (
+          <button
+            onClick={onClose}
+            className="flex items-center gap-2 text-neutral-600 hover:text-neutral-900"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        ) : (
+          <div className="w-5"></div>
+        )}
         <h2 className="text-lg font-semibold">위치 정보 설정</h2>
         <div className="w-8"></div>
       </div>

--- a/apps/web/src/hooks/auth/useSignupFlow.ts
+++ b/apps/web/src/hooks/auth/useSignupFlow.ts
@@ -15,11 +15,11 @@ export const useSignupFlow = () => {
   const goToDone = () => setCurrentStep('done');
 
   const handleSaveLocation = () => {
-    console.log('위치 저장 완료');
     goToDone();
   };
 
   const handleStartActivity = () => {
+    document.cookie = 'signup-flow=; path=/; max-age=0';
     router.push('/');
   };
 

--- a/apps/web/src/hooks/auth/useSignupForm.ts
+++ b/apps/web/src/hooks/auth/useSignupForm.ts
@@ -57,6 +57,8 @@ export const useSignupForm = () => {
     }
 
     return withSubmission(async () => {
+      // 회원가입 플로우 시작 표시 (1시간 유효)
+      document.cookie = 'signup-flow=active; path=/; max-age=3600; SameSite=Lax';
       // Server Action 호출
       const result = await signUp(submitFormData);
 
@@ -65,6 +67,8 @@ export const useSignupForm = () => {
         console.log('회원가입 성공:', result.message);
         return { success: true, result };
       } else {
+        // 실패시 플로우 상태 제거
+        document.cookie = 'signup-flow=; path=/; max-age=0';
         const serverErrors: Record<string, string> = {};
 
         if (result.field === 'email') {

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -86,6 +86,15 @@ export async function updateSession(request: NextRequest) {
       console.log(`🔄 [Authenticated Redirect] ${pathname} → ${destination}`);
     }
 
+    // 회원가입 페이지의 경우 플로우 상태 확인
+    if (pathname.startsWith('/auth/signup')) {
+      const signupFlowCookie = request.cookies.get('signup-flow')?.value;
+
+      if (signupFlowCookie === 'active') {
+        return supabaseResponse;
+      }
+    }
+
     const redirectResponse = NextResponse.redirect(new URL(destination, request.url));
 
     //쿠키 복사


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
closes #342 
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
회원가입 플로우시 쿠키를 생성하여 회원가입 플로우때 미들웨어에서 홈으로 리다이렉트 되는 문제 해결
회원가입완료(쿠키 생성) 회원가입 플로우 진행(위치등록, 완료) -> 쿠키 삭제 -> 홈으로 리다이렉트
회원가입 플로우 쿠키가 있을시 위치 등록 모달에서 x 버튼 랜더링 안되게 수정

홈 셀렉박스 내위치 설정 클릭시 위치 등록 페이지로 네비게이션 추가

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

`signup-flow` 쿠키를 통해 회원가입 내비게이션을 관리하여 의도치 않은 리다이렉션을 방지하고, 회원가입 후 홈 내비게이션 바 가시성을 복원합니다.

버그 수정:
- 미들웨어에서 `signup-flow` 쿠키를 확인하여 회원가입 흐름 중 인증 리다이렉션을 우회합니다.
- 회원가입 완료 후 `signup-flow` 상태를 올바르게 초기화하여 홈 내비게이션 바 가시성을 복원합니다.

개선 사항:
- 회원가입 시작 시 `signup-flow` 쿠키를 설정(1시간 만료)하고, 실패 또는 완료 시 초기화합니다.
- 회원가입 흐름 중에는 내비게이션을 강제하기 위해 위치 선택기의 닫기 버튼을 숨깁니다.
- 홈 필터 선택에서 "내 동네 설정" 링크를 업데이트하여 `/location` 페이지로 이동하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Manage signup navigation via a `signup-flow` cookie to prevent unintended redirects and restore home navbar visibility after signup.

Bug Fixes:
- Bypass authentication redirects during the signup flow by checking the `signup-flow` cookie in middleware
- Restore home navigation bar visibility after completing signup by properly clearing the signup-flow state

Enhancements:
- Set a `signup-flow` cookie at signup start (1-hour expiry) and clear it on failure or completion
- Hide the location picker’s close button when in the signup flow to enforce navigation
- Update "내 동네 설정" link in the home filter select to navigate to the `/location` page

</details>