### PR TITLE
[Feat]설정,고객센터,404페이지 파일생성

### DIFF
--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import Container from '@/components/layout/container';
+const NotFound = () => {
+  return (
+    <Container>
+      <div>요청하신 페이지는 존재하지 않습니다.</div>
+    </Container>
+  );
+};
+
+export default NotFound;

--- a/apps/web/app/settings/layout.tsx
+++ b/apps/web/app/settings/layout.tsx
@@ -1,6 +1,6 @@
 import { SettingsHeader, Container } from '@/components/layout';
 
-const SettiongsLayout = ({ children }: { children: React.ReactNode }) => {
+const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <SettingsHeader />
@@ -9,4 +9,4 @@ const SettiongsLayout = ({ children }: { children: React.ReactNode }) => {
   );
 };
 
-export default SettiongsLayout;
+export default SettingsLayout;

--- a/apps/web/app/settings/layout.tsx
+++ b/apps/web/app/settings/layout.tsx
@@ -1,0 +1,12 @@
+import { SettingsHeader, Container } from '@/components/layout';
+
+const SettiongsLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <>
+      <SettingsHeader />
+      <Container>{children}</Container>
+    </>
+  );
+};
+
+export default SettiongsLayout;

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,0 +1,5 @@
+const Page = () => {
+  return <div> 설정 페이지</div>;
+};
+
+export default Page;

--- a/apps/web/app/support/layout.tsx
+++ b/apps/web/app/support/layout.tsx
@@ -1,0 +1,12 @@
+import { SupportHeader, Container } from '@/components/layout';
+
+const SupportLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <>
+      <SupportHeader />
+      <Container>{children}</Container>
+    </>
+  );
+};
+
+export default SupportLayout;

--- a/apps/web/app/support/page.tsx
+++ b/apps/web/app/support/page.tsx
@@ -1,0 +1,5 @@
+const Page = () => {
+  return <div> 고객지원 페이지</div>;
+};
+
+export default Page;

--- a/apps/web/src/components/layout/header/settings.tsx
+++ b/apps/web/src/components/layout/header/settings.tsx
@@ -8,11 +8,11 @@ import { HeaderWrapper } from '@/components/layout';
 import { Button } from '@/components/ui';
 
 const SettingsHeader = () => {
-  const routes = useRouter();
+  const router = useRouter();
 
   return (
     <HeaderWrapper className="justify-start bg-white">
-      <Button variant="solid" color="transparent" onClick={() => routes.back()}>
+      <Button variant="solid" color="transparent" onClick={() => router.back()}>
         <ChevronLeftIcon />
       </Button>
       <h2 className="text-h4 absolute left-1/2 -translate-x-1/2 font-bold">설정</h2>

--- a/apps/web/src/components/layout/header/settings.tsx
+++ b/apps/web/src/components/layout/header/settings.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { ChevronLeftIcon } from 'lucide-react';
+
+import { HeaderWrapper } from '@/components/layout';
+import { Button } from '@/components/ui';
+
+const SettingsHeader = () => {
+  const routes = useRouter();
+
+  return (
+    <HeaderWrapper className="justify-start bg-white">
+      <Button variant="solid" color="transparent" onClick={() => routes.back()}>
+        <ChevronLeftIcon />
+      </Button>
+      <h2 className="text-h4 absolute left-1/2 -translate-x-1/2 font-bold">설정</h2>
+    </HeaderWrapper>
+  );
+};
+
+export default SettingsHeader;

--- a/apps/web/src/components/layout/header/support.tsx
+++ b/apps/web/src/components/layout/header/support.tsx
@@ -8,11 +8,11 @@ import { HeaderWrapper } from '@/components/layout';
 import { Button } from '@/components/ui';
 
 const SupportHeader = () => {
-  const routes = useRouter();
+  const router = useRouter();
 
   return (
     <HeaderWrapper className="justify-start bg-white">
-      <Button variant="solid" color="transparent" onClick={() => routes.back()}>
+      <Button variant="solid" color="transparent" onClick={() => router.back()}>
         <ChevronLeftIcon />
       </Button>
       <h2 className="text-h4 absolute left-1/2 -translate-x-1/2 font-bold">고객 센터</h2>

--- a/apps/web/src/components/layout/header/support.tsx
+++ b/apps/web/src/components/layout/header/support.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { ChevronLeftIcon } from 'lucide-react';
+
+import { HeaderWrapper } from '@/components/layout';
+import { Button } from '@/components/ui';
+
+const SupportHeader = () => {
+  const routes = useRouter();
+
+  return (
+    <HeaderWrapper className="justify-start bg-white">
+      <Button variant="solid" color="transparent" onClick={() => routes.back()}>
+        <ChevronLeftIcon />
+      </Button>
+      <h2 className="text-h4 absolute left-1/2 -translate-x-1/2 font-bold">고객 센터</h2>
+    </HeaderWrapper>
+  );
+};
+
+export default SupportHeader;

--- a/apps/web/src/components/layout/index.ts
+++ b/apps/web/src/components/layout/index.ts
@@ -7,6 +7,8 @@ export { default as ChatHeader } from './header/chat';
 export { default as ProfileHeader } from './header/profile';
 export { default as AccountHeader } from './header/account';
 export { default as LocationHeader } from './header/location';
+export { default as SupportHeader } from './header/support';
+export { default as SettingsHeader } from './header/settings';
 
 export { default as HomeFilterSelect } from './home-filter-select';
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
closes #364 
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

설정,고객센터,404페이지 파일생성

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

전용 헤더와 레이아웃을 갖춘 새로운 설정 및 지원 섹션을 추가하고, 사용자 정의 404 페이지를 도입합니다.

새로운 기능:
- 뒤로 가기 탐색 및 지역화된 제목을 포함하는 SupportHeader 및 SettingsHeader 컴포넌트 추가
- /settings 및 /support 경로에 각각의 헤더를 포함하는 레이아웃 생성
- app 디렉터리 아래에 기본적인 설정 및 지원 페이지 추가
- Container 레이아웃을 사용하여 app/not-found.tsx에 사용자 정의 NotFound 페이지 구현

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new settings and support sections with dedicated headers and layouts, and introduce a custom 404 page

New Features:
- Add SupportHeader and SettingsHeader components with back navigation and localized titles
- Create layouts for /settings and /support routes that include their respective headers
- Add basic settings and support pages under the app directory
- Implement a custom NotFound page at app/not-found.tsx using the Container layout

</details>