### PR TITLE
[Fix]: 등록된 위치가 없을경우 셀렉박스 역삼동 보여주기

### DIFF
--- a/apps/web/src/components/layout/home-filter-select.tsx
+++ b/apps/web/src/components/layout/home-filter-select.tsx
@@ -115,7 +115,7 @@ const HomeFilterSelect = () => {
         <PopoverContent align="start" className="w-34">
           <ul className="space-y-3">
             <li>
-              <button>{getDisplayName(selectedLocation.locationName)}</button>
+              <span>{getDisplayName(selectedLocation.locationName)}</span>
             </li>
             <li>
               <Link href="/location">내 동네 설정</Link>

--- a/apps/web/src/components/layout/home-filter-select.tsx
+++ b/apps/web/src/components/layout/home-filter-select.tsx
@@ -102,14 +102,29 @@ const HomeFilterSelect = () => {
   // 등록된 위치가 없는 경우
   if (!userLocations || userLocations.length === 0) {
     return (
-      <Link href="/" className={cn(homeFilterWrapper, 'text-primary-600 gap-2')}>
-        <MapPin size={16} />
-        위치 설정
-        <ChevronRight size={24} />
-      </Link>
+      <Popover open={isSelectOpen} onOpenChange={setIsSelectOpen}>
+        <PopoverTrigger asChild>
+          <button
+            aria-label="서비스 위치 선택"
+            className={cn(homeFilterWrapper, 'hover:text-primary-600 gap-2 transition-colors')}
+          >
+            {getDisplayName(selectedLocation.locationName)}
+            <ChevronDown size={24} className={homeFilterIcon({ open: isSelectOpen })} />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-34">
+          <ul className="space-y-3">
+            <li>
+              <button>{getDisplayName(selectedLocation.locationName)}</button>
+            </li>
+            <li>
+              <Link href="/location">내 동네 설정</Link>
+            </li>
+          </ul>
+        </PopoverContent>
+      </Popover>
     );
   }
-
   // 등록된 위치가 있는 경우
   return (
     <Popover open={isSelectOpen} onOpenChange={setIsSelectOpen}>

--- a/apps/web/src/components/personal-info/location/button-box.tsx
+++ b/apps/web/src/components/personal-info/location/button-box.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui';
 import { useUserLocations } from '@/hooks/queries/location/useUserLocations';
 
 import { deleteLocation, setPrimaryLocation } from '@/lib/actions/location';
+import { useToastStore } from '@/lib/zustand/store/toast-store';
 
 interface ButtonBoxProps {
   locationId: string;
@@ -18,6 +19,7 @@ const LocationButtonBox = ({ locationId }: ButtonBoxProps) => {
   const [isDeleting, setIsDeleting] = useState(false);
   const [isSettingPrimary, setIsSettingPrimary] = useState(false);
   const { refetch } = useUserLocations();
+  const { showToast } = useToastStore();
 
   // 기본 위치 설정 함수
   const handleSetPrimary = async () => {
@@ -26,11 +28,27 @@ const LocationButtonBox = ({ locationId }: ButtonBoxProps) => {
       const result = await setPrimaryLocation(locationId);
       if (result.success) {
         await refetch();
+        showToast({
+          status: 'success',
+          title: '기본 위치 설정 완료',
+          subtext: result.message || '기본 위치가 변경되었습니다.',
+          autoClose: true,
+        });
       } else {
-        console.error('❌ 기본 위치 설정 실패:', result.error);
+        showToast({
+          status: 'error',
+          title: '기본 위치 설정 실패',
+          subtext: result.error || '기본 위치 설정에 실패했습니다.',
+          autoClose: true,
+        });
       }
     } catch (error) {
-      console.error('❌ 기본 위치 설정 오류:', error);
+      showToast({
+        status: 'error',
+        title: '기본 위치 설정 오류',
+        subtext: '예상치 못한 오류가 발생했습니다.',
+        autoClose: true,
+      });
     } finally {
       setIsSettingPrimary(false);
     }
@@ -38,20 +56,32 @@ const LocationButtonBox = ({ locationId }: ButtonBoxProps) => {
 
   // 삭제 함수
   const handleDelete = async () => {
-    if (!window.confirm('이 위치를 삭제하시겠습니까?')) {
-      return;
-    }
-
     setIsDeleting(true);
     try {
       const result = await deleteLocation(locationId);
       if (result.success) {
         await refetch();
+        showToast({
+          status: 'success',
+          title: '위치 삭제 완료',
+          subtext: result.message || '위치가 성공적으로 삭제되었습니다.',
+          autoClose: true,
+        });
       } else {
-        console.error('❌ 위치 삭제 실패:', result.error);
+        showToast({
+          status: 'error',
+          title: '위치 삭제 실패',
+          subtext: result.error || '위치 삭제에 실패했습니다.',
+          autoClose: true,
+        });
       }
     } catch (error) {
-      console.error('❌ 위치 삭제 오류:', error);
+      showToast({
+        status: 'error',
+        title: '위치 삭제 오류',
+        subtext: '예상치 못한 오류가 발생했습니다.',
+        autoClose: true,
+      });
     } finally {
       setIsDeleting(false);
     }

--- a/apps/web/src/components/personal-info/location/location-list.tsx
+++ b/apps/web/src/components/personal-info/location/location-list.tsx
@@ -24,6 +24,22 @@ const LocationList = () => {
     );
   }
 
+  if (!userLocations || userLocations.length === 0) {
+    return (
+      <div className="flex h-full w-full flex-col justify-between px-4 pb-4">
+        <div className="flex flex-col items-center justify-center py-16">
+          <h3 className="mb-2 text-lg font-medium text-neutral-900">등록된 위치가 없습니다</h3>
+          <p className="text-center text-neutral-600">
+            위치를 등록하시면
+            <br />
+            해당 지역의 경매 정보를 확인할 수 있습니다
+          </p>
+        </div>
+        <LocationButtonCreate status={status}>위치 추가하기</LocationButtonCreate>
+      </div>
+    );
+  }
+
   return (
     <div className="flex h-full w-full flex-col justify-between px-4 pb-4">
       <ul className="flex flex-col gap-3">


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
closes #368 
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

소셜 로그인으로 회원가입시 초기 위치 등록이 안되어 있는데 이때 홈 셀렉 박스에 역삼동(기본값 매핑) 롤벡
위치 등록 페이지에 등록된 위치가 없을 경우 안내 텍스트 추가

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

사용자가 등록된 위치가 없을 때, 홈 필터에 기본 팝오버를 표시하고 위치 목록 페이지에는 '위치 추가' 버튼과 함께 정보를 제공하는 빈 상태를 보여주도록 처리합니다.

개선 사항:
- 등록된 위치가 없을 때, 홈 필터에 기본 위치 이름과 위치 설정 링크가 포함된 팝오버를 표시합니다.
- 사용자가 저장된 위치가 없을 때, 위치 목록 컴포넌트에 빈 상태 메시지와 "위치 추가하기" 버튼을 표시합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle the scenario when the user has no registered locations by displaying a default popover in the home filter and showing an informative empty state with an add-location button on the location list page.

Enhancements:
- Show a popover with the default location name and a link to location settings in the home filter when no locations are registered
- Display an empty-state message and a "위치 추가하기" button in the location list component when the user has no saved locations

</details>