### PR TITLE
[fix] chat api 호출 에러 해결

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -67,9 +67,6 @@ export async function GET(request: NextRequest) {
           },
         },
       },
-      orderBy: {
-        lastMessageAt: 'desc', // 최근 메시지 순
-      },
     });
 
     const optimizedChatRooms = chatRooms.map((room) => {
@@ -77,7 +74,7 @@ export async function GET(request: NextRequest) {
       const { sellerId, buyerId, seller, buyer, ...cleanRoom } = room;
 
       return {
-        ...cleanRoom, // id, auctionId, createdAt, lastMessageAt, isDeleted, auction, messages
+        ...cleanRoom, // id, auctionId, createdAt, isDeleted, auction, messages
         myRole: user.id === sellerId ? 'seller' : 'buyer',
         otherUser: user.id === sellerId ? buyer : seller, // 대화 상대방 데이터
       };

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 
 import { prisma } from '@repo/db';
 

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -4,7 +4,7 @@ import { prisma } from '@repo/db';
 
 import { createClient } from '@/lib/supabase/server';
 
-export async function GET(request: NextRequest) {
+export async function GET() {
   try {
     const supabase = await createClient();
 
@@ -71,7 +71,7 @@ export async function GET(request: NextRequest) {
 
     const optimizedChatRooms = chatRooms.map((room) => {
       // seller, buyer는 계산용으로만 사용하고 최종 응답에서 제외
-      const { sellerId, buyerId, seller, buyer, ...cleanRoom } = room;
+      const { sellerId, seller, buyer, ...cleanRoom } = room;
 
       return {
         ...cleanRoom, // id, auctionId, createdAt, isDeleted, auction, messages

--- a/apps/web/src/lib/types/chat.ts
+++ b/apps/web/src/lib/types/chat.ts
@@ -17,7 +17,6 @@ export interface ChatRoom {
   id: string;
   auctionId: string;
   createdAt: string;
-  lastMessageAt: string | null;
   isDeleted: boolean;
   myRole: 'seller' | 'buyer';
   otherUser: {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #377 

## 📋 작업 내용

1. 채팅 페이지 진입시 채팅 목록을 호출 에러 발생
  `GET /api/chat 500 in 931ms
🔍 [Middleware] /api/chat | User: jelly@test.com
채팅방 목록 조회 에러: Error [PrismaClientKnownRequestError]: 
Invalid prisma.chatRoom.findMany() invocation:
The column chat_rooms.last_message_at does not exist in the current database.` 

2. 사용하지 않는 데이터 lastMessageAt을 chatRoom 호출 api에 포함
=> 호출 로직에서 삭제 처리

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
