### PR TITLE
[feat] 즉시거래 기능 구현

### DIFF
--- a/apps/web/src/components/auction-create/form-create.tsx
+++ b/apps/web/src/components/auction-create/form-create.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { CircleAlert } from 'lucide-react';
 
 import {
@@ -7,7 +9,9 @@ import {
   MinUnitSelectBox,
   Notice,
 } from '@/components/common';
-import { Input, Label, Textarea } from '@/components/ui';
+import { Input, Label, Popover, PopoverContent, PopoverTrigger, Textarea } from '@/components/ui';
+
+import { Checkbox } from '../ui/checkbox';
 const colClass = 'space-y-2 [&_label]:text-sm [&_label]:text-neutral-900 [&_label]:font-medium';
 
 interface DefaultValuesType {
@@ -43,6 +47,8 @@ const CreateAuctionForm = ({
   onRemoveExistingImage,
   currentPriceInfo, // 현재가 정보
 }: CreateAuctionFormProps) => {
+  const [isInstantBuyEnabled, setIsInstantBuyEnabled] = useState(false);
+
   const formatPrice = (price: number) => price.toLocaleString() + '원';
 
   return (
@@ -188,6 +194,47 @@ const CreateAuctionForm = ({
         )}
 
         {errors['end_time'] && <FormErrorMessage>{errors['end_time']}</FormErrorMessage>}
+      </div>
+      <div className={`flex flex-col gap-2`}>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="instant"
+            name="instant"
+            checked={isInstantBuyEnabled}
+            onCheckedChange={(checked) => setIsInstantBuyEnabled(!!checked)}
+          />
+          <Label htmlFor="instant" className="text-md font-light">
+            즉시 구매 사용하기
+          </Label>
+          <Popover>
+            <PopoverTrigger asChild>
+              <CircleAlert className="text-xs font-thin" width={20} height={20} strokeWidth={1} />
+            </PopoverTrigger>
+            <PopoverContent side="right" align="center" className="w-64 text-sm">
+              즉시구매가 : 현재 가 * 1.2배
+              <br />
+              빠른 입찰을 원하신다면 즉시 구매를 이용해보세요.
+            </PopoverContent>
+          </Popover>
+        </div>
+        {/* 숨겨진 input으로 값 전달 */}
+        <input type="hidden" name="is_instant_buy_enabled" value={isInstantBuyEnabled.toString()} />
+      </div>
+      <div className={`flex items-center gap-2`}>
+        <Checkbox id="extend" />
+        <Label htmlFor="extend" className="text-md font-light">
+          연장 경매 사용하기
+        </Label>
+        <Popover>
+          <PopoverTrigger asChild>
+            <CircleAlert className="text-xs font-thin" width={20} height={20} strokeWidth={1} />
+          </PopoverTrigger>
+          <PopoverContent side="right" align="center" className="w-64 text-sm">
+            경매마감 1분 전에, 연장 버튼이 활성화
+            <br />
+            경매 당 3분 연장 1회 가능(1인 1회)
+          </PopoverContent>
+        </Popover>
       </div>
     </div>
   );

--- a/apps/web/src/components/auction-detail/bid-form/button-direct-deal.tsx
+++ b/apps/web/src/components/auction-detail/bid-form/button-direct-deal.tsx
@@ -1,14 +1,54 @@
+import { useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
 import { AlarmClock, ChevronRight } from 'lucide-react';
+
+import { createChatRoom } from '@/lib/actions/chat';
 
 interface ButtonDirectDealProps {
   directPrice: string;
+  auctionId: string;
+  sellerId: string;
 }
 
-const ButtonDirectDeal = ({ directPrice }: ButtonDirectDealProps) => {
+const ButtonDirectDeal = ({ directPrice, auctionId, sellerId }: ButtonDirectDealProps) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
+
+  const handleDirectDeal = async () => {
+    try {
+      setIsLoading(true);
+
+      // 즉시거래 확인 알림
+      const confirmed = window.confirm(
+        `${directPrice}에 즉시 구매하시겠습니까?\n구매 확정 시 채팅방으로 이동합니다.`
+      );
+
+      if (!confirmed) return;
+
+      // 채팅방 생성
+      const chatRoomId = await createChatRoom({
+        auctionId,
+        sellerId,
+      });
+
+      // 채팅방으로 이동
+      router.push(`/chat/${chatRoomId}`);
+    } catch (error) {
+      console.error('즉시거래 처리 중 오류:', error);
+      alert('즉시거래 처리 중 오류가 발생했습니다. 다시 시도해주세요.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return (
     <button
       type="button"
       className="bg-primary-50 mb-1 flex w-full items-center justify-between gap-2 rounded-sm py-2.5 pl-4 pr-2"
+      onClick={handleDirectDeal}
+      disabled={isLoading}
     >
       <AlarmClock className="text-indigo-500" strokeWidth={2.5} size={20} />
       <p className="flex-1 pt-0.5 text-left font-medium text-neutral-900">

--- a/apps/web/src/components/auction-detail/bid-form/button-direct-deal.tsx
+++ b/apps/web/src/components/auction-detail/bid-form/button-direct-deal.tsx
@@ -10,13 +10,30 @@ interface ButtonDirectDealProps {
   directPrice: string;
   auctionId: string;
   sellerId: string;
+  currentUserId?: string;
 }
 
-const ButtonDirectDeal = ({ directPrice, auctionId, sellerId }: ButtonDirectDealProps) => {
+const ButtonDirectDeal = ({
+  directPrice,
+  auctionId,
+  sellerId,
+  currentUserId,
+}: ButtonDirectDealProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
 
+  // 본인 경매인지 확인
+  const isOwnAuction = currentUserId === sellerId;
+
   const handleDirectDeal = async () => {
+    // 본인 경매인 경우 안내 메시지
+    if (isOwnAuction) {
+      alert(
+        '본인의 경매 상품은 즉시거래를 할 수 없습니다.\n다른 사용자가 즉시거래를 진행할 수 있습니다.'
+      );
+      return;
+    }
+
     try {
       setIsLoading(true);
 
@@ -46,7 +63,7 @@ const ButtonDirectDeal = ({ directPrice, auctionId, sellerId }: ButtonDirectDeal
   return (
     <button
       type="button"
-      className="bg-primary-50 mb-1 flex w-full items-center justify-between gap-2 rounded-sm py-2.5 pl-4 pr-2"
+      className={`bg-primary-50 mb-1 flex w-full items-center justify-between gap-2 rounded-sm py-2.5 pl-4 pr-2 ${isOwnAuction ? 'opacity-60' : ''}`}
       onClick={handleDirectDeal}
       disabled={isLoading}
     >

--- a/apps/web/src/components/auction-detail/bid-form/button-direct-deal.tsx
+++ b/apps/web/src/components/auction-detail/bid-form/button-direct-deal.tsx
@@ -63,7 +63,7 @@ const ButtonDirectDeal = ({
   return (
     <button
       type="button"
-      className={`bg-primary-50 mb-1 flex w-full items-center justify-between gap-2 rounded-sm py-2.5 pl-4 pr-2 ${isOwnAuction ? 'opacity-60' : ''}`}
+      className={`bg-primary-50 mb-1 flex w-full items-center justify-between gap-2 rounded-sm py-2.5 pl-4 pr-2`}
       onClick={handleDirectDeal}
       disabled={isLoading}
     >

--- a/apps/web/src/components/auction-detail/bid-form/form.tsx
+++ b/apps/web/src/components/auction-detail/bid-form/form.tsx
@@ -99,7 +99,16 @@ const BidForm = ({ auctionId, currentPrice, endTime, bidTableRef }: BidFormProps
           'duration-600 relative rounded-t-sm bg-white px-5 pt-4 shadow-[var(--shadow-nav)] transition-all'
         )}
       >
-        {!isExpired && <ButtonDirectDeal directPrice={directPrice} />}
+        {/* 즉시거래 버튼 - 경매가 종료되지 않았고 즉시거래가 활성화된 경우에만 표시 */}
+        {!isExpired && data?.data.auctionPrice?.isInstantBuyEnabled && (
+          <ButtonDirectDeal
+            directPrice={formatCurrencyWithUnit(
+              data.data.auctionPrice.instantPrice || currentPrice * 1.2
+            )}
+            auctionId={auctionId}
+            sellerId={data.data.sellerId}
+          />
+        )}
 
         <BidFormInput
           auctionId={auctionId}

--- a/apps/web/src/components/auction-detail/bid-form/form.tsx
+++ b/apps/web/src/components/auction-detail/bid-form/form.tsx
@@ -14,7 +14,13 @@ import { formatCurrencyWithUnit } from '@/lib/utils/price';
 
 import { BidFormProps } from '@/types/bid';
 
-const BidForm = ({ auctionId, currentPrice, endTime, bidTableRef }: BidFormProps) => {
+const BidForm = ({
+  auctionId,
+  currentPrice,
+  endTime,
+  bidTableRef,
+  currentUserId,
+}: BidFormProps) => {
   const [bidPrice, setBidPrice] = useState<number | null>(null);
   const [validationError, setValidationError] = useState<string>('');
 
@@ -26,7 +32,10 @@ const BidForm = ({ auctionId, currentPrice, endTime, bidTableRef }: BidFormProps
 
   // 경매 종료 시간까지의 카운트다운
   const { isExpired } = useCountdown(new Date(endTime));
-  const directPrice = formatCurrencyWithUnit(currentPrice * 1.2); // 20% 증가한 가격
+  //const directPrice = formatCurrencyWithUnit(currentPrice * 1.2); // 20% 증가한 가격
+
+  // 본인 경매인지 확인
+  const isOwnAuction = currentUserId && data?.data.sellerId === currentUserId;
 
   // 입찰 가격 변경 시 검증
   const handleBidPriceChange = (price: number | null) => {
@@ -47,6 +56,12 @@ const BidForm = ({ auctionId, currentPrice, endTime, bidTableRef }: BidFormProps
     // 경매가 종료된 경우 입찰 불가
     if (isExpired) {
       alert('경매가 종료되어 입찰할 수 없습니다.');
+      return;
+    }
+
+    // 본인 경매 입찰 방지
+    if (isOwnAuction) {
+      alert('본인의 경매에는 입찰할 수 없습니다.');
       return;
     }
 
@@ -107,6 +122,7 @@ const BidForm = ({ auctionId, currentPrice, endTime, bidTableRef }: BidFormProps
             )}
             auctionId={auctionId}
             sellerId={data.data.sellerId}
+            currentUserId={currentUserId}
           />
         )}
 

--- a/apps/web/src/components/auction-detail/container.tsx
+++ b/apps/web/src/components/auction-detail/container.tsx
@@ -15,6 +15,7 @@ import {
 import { ProfileCard } from '@/components/common';
 
 import { useAuctionDetail } from '@/hooks/queries/auction';
+import { useCurrentUser } from '@/hooks/queries/auth';
 import { useBidsByAuction } from '@/hooks/queries/bids';
 
 import { cn } from '@/lib/cn';
@@ -25,6 +26,9 @@ const AuctionDetailContainer = () => {
   const bidTableRef = useRef<HTMLDivElement>(null);
   const params = useParams();
   const { id } = params;
+
+  // 현재 사용자 정보 훅 사용
+  const { data: currentUser } = useCurrentUser();
 
   const {
     data: auctionDetailData,
@@ -122,6 +126,7 @@ const AuctionDetailContainer = () => {
           endTime={item.endTime}
           bidTableRef={bidTableRef}
           isExpired={false}
+          currentUserId={currentUser?.id} // 현재 사용자 ID 전달
         />
       </aside>
     </>

--- a/apps/web/src/hooks/auction/useCreateAuction.tsx
+++ b/apps/web/src/hooks/auction/useCreateAuction.tsx
@@ -54,6 +54,8 @@ const useCreateAuction = () => {
             min_bid_unit: Number(formData.get('min_bid_unit') ?? 0),
           },
           end_time: String(formData.get('end_time') ?? ''),
+          is_instant_buy_enabled: formData.get('is_instant_buy_enabled') === 'true',
+          is_extended_auction: formData.get('is_extended_auction') === 'true',
         };
 
         // Zod 유효성 검사
@@ -83,8 +85,18 @@ const useCreateAuction = () => {
 
         setErrors({});
 
+        const startPrice = rawData.prices.start_price;
+
         const phasedData: CreateAuctionFormData = {
           ...result.data,
+          is_instant_buy_enabled: rawData.is_instant_buy_enabled,
+          is_extended_auction: rawData.is_extended_auction,
+          prices: {
+            ...result.data.prices,
+            instant_price: rawData.is_instant_buy_enabled
+              ? Math.floor(startPrice * 1.2)
+              : undefined,
+          },
         };
 
         // try 블록 제거 (이미 위에서 시작)

--- a/apps/web/src/hooks/queries/auth/index.ts
+++ b/apps/web/src/hooks/queries/auth/index.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getCurrentUserClient } from '@/lib/utils/auth-client';
+
+export const useCurrentUser = () => {
+  return useQuery({
+    queryKey: ['currentUser'],
+    queryFn: getCurrentUserClient, // 클라이언트용 함수 사용
+    staleTime: 1000 * 60 * 5, // 5분간 캐시
+    gcTime: 1000 * 60 * 10, // 10분간 메모리에 보관
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+};
+export type UseCurrentUserReturn = ReturnType<typeof useCurrentUser>;

--- a/apps/web/src/lib/actions/auction.ts
+++ b/apps/web/src/lib/actions/auction.ts
@@ -5,17 +5,12 @@ import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase/server';
 import { convertHoursToTimestamp } from '@/lib/utils/date';
 
-import { AuctionFormData } from '@/types/auction';
+import { AuctionFormData, AuctionPriceUpdate } from '@/types/auction';
 
 // Create
 export const createAuction = async (data: AuctionFormData, userId: string) => {
   try {
     const supabase = await createClient();
-
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
 
     // 1. 유저의 기본 위치 조회
     const { data: primaryLocation, error: locationError } = await supabase
@@ -61,9 +56,11 @@ export const createAuction = async (data: AuctionFormData, userId: string) => {
     const { error: priceError } = await supabase.from('auction_prices').insert({
       item_id: itemId,
       start_price: data.prices.start_price,
-      instant_price: data.prices.instant_price,
+      instant_price: data.prices.instant_price || null, // 즉시거래가 추가
       min_bid_unit: data.prices.min_bid_unit,
       current_price: data.prices.start_price,
+      is_instant_buy_enabled: data.is_instant_buy_enabled, // 즉시거래 활성화 여부
+      is_extended_auction: data.is_extended_auction || false, // 연장경매 여부
     });
 
     if (priceError) {
@@ -179,9 +176,11 @@ export const updateAuction = async (data: AuctionFormData, itemId: string) => {
     }
 
     // 6. auction_prices 안전한 업데이트
-    const priceUpdateData: any = {
+    const priceUpdateData: AuctionPriceUpdate = {
       instant_price: data.prices.instant_price,
       min_bid_unit: data.prices.min_bid_unit,
+      is_instant_buy_enabled: data.is_instant_buy_enabled,
+      is_extended_auction: data.is_extended_auction || false,
     };
 
     // 입찰이 없는 경우에만 start_price와 current_price 업데이트

--- a/apps/web/src/lib/actions/chat.ts
+++ b/apps/web/src/lib/actions/chat.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { createClient } from '@/lib/supabase/client';
-import { getCurrentUser } from '@/lib/utils/auth';
+import { getCurrentUser } from '@/lib/utils/auth-server';
 
 import { CreateChatRoomProps } from '@/types/chat';
 

--- a/apps/web/src/lib/actions/location.ts
+++ b/apps/web/src/lib/actions/location.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 
 import { createClient } from '@/lib/supabase/server';
-import { getCurrentUser } from '@/lib/utils/auth';
+import { getCurrentUser } from '@/lib/utils/auth-server';
 
 import type { Location } from '@/types/location';
 

--- a/apps/web/src/lib/actions/profile.ts
+++ b/apps/web/src/lib/actions/profile.ts
@@ -5,7 +5,7 @@ import { prisma } from '@repo/db';
 
 import { getUserProfileFromDB } from '@/lib/data/user';
 import { uploadProfileImageServer } from '@/lib/supabase/storage-server';
-import { getCurrentUser } from '@/lib/utils/auth';
+import { getCurrentUser } from '@/lib/utils/auth-server';
 
 export const getMyProfile = async () => {
   try {

--- a/apps/web/src/lib/schema/auction.schema.ts
+++ b/apps/web/src/lib/schema/auction.schema.ts
@@ -9,12 +9,15 @@ export const createAuctionSchema = z.object({
       .number({ message: '경매 시작가는 1,000원 이상이어야 합니다.' })
       .min(1000, '경매 시작가는 1,000원 이상이어야 합니다.'),
     min_bid_unit: z.coerce.number().min(1, '최소 입찰 금액을 선택해주세요.'),
+    instant_price: z.coerce.number().optional(),
   }),
   end_time: z
     .string()
     .min(1, '경매 종료시간을 입력해주세요.')
     .max(2, '최대 99시간까지 입력할 수 있어요.'),
   images: z.array(z.string()).optional(),
+  is_instant_buy_enabled: z.boolean().default(false),
+  is_extended_auction: z.boolean().default(false).optional(),
 });
 
 export type CreateAuctionFormData = z.infer<typeof createAuctionSchema>;

--- a/apps/web/src/lib/types/auction.ts
+++ b/apps/web/src/lib/types/auction.ts
@@ -25,6 +25,9 @@ export interface AuctionFormData {
   end_time: string;
   auction_type?: 'normal' | 'flash';
   images?: string[];
+  // 추가된 필드
+  is_instant_buy_enabled: boolean;
+  is_extended_auction?: boolean;
 }
 
 export interface Auction extends AuctionFormData {
@@ -33,6 +36,16 @@ export interface Auction extends AuctionFormData {
   status: AuctionStatus;
   thumbnail_url: string;
   created_at: string;
+}
+
+export interface AuctionPriceUpdate {
+  instant_price?: number | null;
+  min_bid_unit: number;
+  is_instant_buy_enabled: boolean;
+  is_extended_auction: boolean;
+  // 입찰이 없을 때만 업데이트되는 필드들
+  start_price?: number;
+  current_price?: number;
 }
 
 export type AuctionStatus =

--- a/apps/web/src/lib/types/bid.ts
+++ b/apps/web/src/lib/types/bid.ts
@@ -26,6 +26,7 @@ export interface BidBaseProps {
   endTime: string | Date; // 경매 종료 시간
   isExpired: boolean;
   isValid?: boolean; // 유효한 입찰단가로 입찰할 수 있는지 여부
+  currentUserId?: string; // 현재 사용자 ID (선택적)
 }
 
 export interface BidFormProps extends BidBaseProps {

--- a/apps/web/src/lib/utils/auth-client.ts
+++ b/apps/web/src/lib/utils/auth-client.ts
@@ -1,0 +1,22 @@
+import { createClient } from '../supabase/client';
+
+// 클라이언트용 함수
+export const getCurrentUserClient = async () => {
+  try {
+    const supabase = createClient();
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
+
+    if (error) {
+      console.error('클라이언트 사용자 정보 조회 에러:', error);
+      return null;
+    }
+
+    return user;
+  } catch (error) {
+    console.error('클라이언트 사용자 정보 조회 예외:', error);
+    return null;
+  }
+};

--- a/apps/web/src/lib/utils/auth-server.ts
+++ b/apps/web/src/lib/utils/auth-server.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@/lib/supabase/server';
 
-// 현재 인증된 사용자 정보를 가져오는 함수
+// 현재 인증된 사용자 정보를 가져오는 함수(서버용 함수)
 export const getCurrentUser = async () => {
   try {
     const supabase = await createClient();


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
closes #357 
## 📋 작업 내용

- 경매 등록폼에 즉시거래 체크박스 추가
- 즉시거래가 자동 계산 로직 (현재가 * 1.2배)
- 경매 상세페이지 즉시결제 버튼 구현
- 즉시결제 시 채팅방 생성 기능
- 타입 정의 및 스키마 업데이트
- 본인이 등록한 경매라면 즉시 구매 불가능 처리

1. **경매 등록**: "즉시 구매 사용하기" 체크 → 즉시거래가 자동 계산
2. **경매 조회**: 즉시거래 활성화된 경매에만 "즉시결제" 버튼 표시
3. **즉시결제**: 확인 팝업 → 채팅방 생성 → 채팅페이지 이동 (만약 내가 등록한 경매라면 alert 표시 및 block 됨)

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
