### PR TITLE
[feat] 경매상세페이지 UI 개선

### DIFF
--- a/apps/web/app/api/bids/route.ts
+++ b/apps/web/app/api/bids/route.ts
@@ -71,6 +71,13 @@ export async function POST(request: NextRequest) {
 
     // 트랜잭션으로 입찰 처리
     const result = await prisma.$transaction(async (tx) => {
+      // 기존 입찰 삭제 (해당 사용자가 이 경매에 한 입찰)
+      await tx.bid.deleteMany({
+        where: {
+          itemId: auctionId,
+          bidderId: user.id,
+        },
+      });
       // 입찰 생성
       const newBid = await tx.bid.create({
         data: {

--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { prisma } from '@repo/db';
 
-import { getCurrentUser } from '@/lib/utils/auth';
+import { getCurrentUser } from '@/lib/utils/auth-server';
 
 export async function GET(request: NextRequest) {
   try {

--- a/apps/web/src/components/auction-create/form-create.tsx
+++ b/apps/web/src/components/auction-create/form-create.tsx
@@ -220,7 +220,7 @@ const CreateAuctionForm = ({
         {/* 숨겨진 input으로 값 전달 */}
         <input type="hidden" name="is_instant_buy_enabled" value={isInstantBuyEnabled.toString()} />
       </div>
-      <div className={`flex items-center gap-2`}>
+      {/* <div className={`flex items-center gap-2`}>
         <Checkbox id="extend" />
         <Label htmlFor="extend" className="text-md font-light">
           연장 경매 사용하기
@@ -235,7 +235,7 @@ const CreateAuctionForm = ({
             경매 당 3분 연장 1회 가능(1인 1회)
           </PopoverContent>
         </Popover>
-      </div>
+      </div> */}
     </div>
   );
 };

--- a/apps/web/src/components/auction-create/form-create.tsx
+++ b/apps/web/src/components/auction-create/form-create.tsx
@@ -22,6 +22,7 @@ interface DefaultValuesType {
   min_bid_unit: number;
   end_time: string;
   images: string[];
+  is_instant_buy_enabled?: boolean;
 }
 interface CurrentPriceInfo {
   startPrice: number;
@@ -47,7 +48,9 @@ const CreateAuctionForm = ({
   onRemoveExistingImage,
   currentPriceInfo, // 현재가 정보
 }: CreateAuctionFormProps) => {
-  const [isInstantBuyEnabled, setIsInstantBuyEnabled] = useState(false);
+  const [isInstantBuyEnabled, setIsInstantBuyEnabled] = useState(
+    defaultValues?.is_instant_buy_enabled || false
+  );
 
   const formatPrice = (price: number) => price.toLocaleString() + '원';
 

--- a/apps/web/src/components/auction-detail/bid-form/form.tsx
+++ b/apps/web/src/components/auction-detail/bid-form/form.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 
+import { X } from 'lucide-react';
+
 import { BidFormBottom, BidFormInput, ButtonDirectDeal } from '@/components/auction-detail';
 
 import useCountdown from '@/hooks/common/useCountdown';
@@ -21,6 +23,7 @@ const BidForm = ({
   bidTableRef,
   currentUserId,
 }: BidFormProps) => {
+  const [isBidInputOpen, setIsBidInputOpen] = useState<boolean>(false);
   const [bidPrice, setBidPrice] = useState<number | null>(null);
   const [validationError, setValidationError] = useState<string>('');
 
@@ -59,6 +62,11 @@ const BidForm = ({
       return;
     }
 
+    if (!isBidInputOpen) {
+      setIsBidInputOpen(true);
+      return;
+    }
+
     // 본인 경매 입찰 방지
     if (isOwnAuction) {
       alert('본인의 경매에는 입찰할 수 없습니다.');
@@ -81,6 +89,11 @@ const BidForm = ({
       // 현재 스크롤 위치 저장
       const currentScrollY = window.scrollY;
 
+      // 입찰 성공 시 상태 초기화
+      setValidationError(''); // 검증 에러 메시지 초기화
+      setBidPrice(null); // 입찰 가격 초기화
+      setIsBidInputOpen(false); // 입찰 성공 시 입찰 입력창 닫기
+
       // API 호출
       await bidMutation.mutateAsync({
         auctionId,
@@ -100,6 +113,7 @@ const BidForm = ({
         });
       }, 100);
     } catch (error) {
+      setIsBidInputOpen(true);
       const errorMessage = error instanceof Error ? error.message : '입찰 중 오류가 발생했습니다.';
       setValidationError(errorMessage);
     }
@@ -108,11 +122,17 @@ const BidForm = ({
   return (
     <form onSubmit={handleBidClick}>
       <div className={cn('w-full bg-white transition-all duration-500 ease-in-out')} />
-
       <div
         className={cn(
-          'duration-600 relative rounded-t-sm bg-white px-5 pt-4 shadow-[var(--shadow-nav)] transition-all'
+          'pointer-events-none absolute inset-x-0 bottom-[98%] z-0 h-2/5',
+          'from-black/16 bg-gradient-to-t to-transparent',
+          'duration-600 transition-all',
+          !isBidInputOpen && 'h-6 opacity-30'
         )}
+      />
+
+      <div
+        className={cn('duration-600 relative z-20 rounded-t-sm bg-white px-5 pt-6 transition-all')}
       >
         {/* 즉시거래 버튼 - 경매가 종료되지 않았고 즉시거래가 활성화된 경우에만 표시 */}
         {!isExpired && data?.data.auctionPrice?.isInstantBuyEnabled && (
@@ -131,10 +151,18 @@ const BidForm = ({
           currentPrice={currentPrice}
           minUnit={minBidUnit}
           bidPrice={bidPrice}
+          isBidInputOpen={isBidInputOpen}
           onChange={handleBidPriceChange}
           validationError={validationError}
         />
       </div>
+      <button
+        type="button"
+        onClick={() => setIsBidInputOpen(false)}
+        className={`duration-600 invisible absolute right-2.5 top-0 translate-y-[-100%] p-2 text-white opacity-0 ${isBidInputOpen && 'visible opacity-100'}`}
+      >
+        <X size={'30'} />
+      </button>
 
       <BidFormBottom
         auctionId={auctionId}

--- a/apps/web/src/components/auction-detail/bid-form/form.tsx
+++ b/apps/web/src/components/auction-detail/bid-form/form.tsx
@@ -73,13 +73,11 @@ const BidForm = ({
       return;
     }
 
-    if (bidPrice === null) {
-      alert('입찰 금액을 입력해주세요');
-      return;
-    }
+    // bidPrice가 null이면 기본값 사용
+    const finalBidPrice = bidPrice ?? currentPrice + minBidUnit;
 
     // 클라이언트 검증
-    const validation = validateBidPrice(bidPrice, currentPrice, minBidUnit || 1000);
+    const validation = validateBidPrice(finalBidPrice, currentPrice, minBidUnit || 1000);
     if (!validation.isValid) {
       setValidationError(validation.message);
       return;
@@ -97,7 +95,7 @@ const BidForm = ({
       // API 호출
       await bidMutation.mutateAsync({
         auctionId,
-        bidPrice,
+        bidPrice: finalBidPrice,
       });
 
       // 성공 시 에러 메시지 초기화

--- a/apps/web/src/components/auction-detail/bid-form/input.tsx
+++ b/apps/web/src/components/auction-detail/bid-form/input.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 
 import { useAuctionDetail } from '@/hooks/queries/auction';
 
-import { formatCurrencyWithUnit } from '@/lib/utils/price';
+import { formatCurrencyWithUnit, formatToKoreanUnit } from '@/lib/utils/price';
 
 import { BidInputProps } from '@/types/bid';
 
@@ -38,21 +38,42 @@ const BidFormInput = ({
 
   const placeholder = `${formatCurrencyWithUnit(currentPrice + minUnit)} 부터`;
 
+  // 기본값을 현재가 + 최소입찰단위로 설정
+  const defaultBidPrice = currentPrice + minBidUnit;
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value.replaceAll(',', '');
     const parsed = Number(value);
     onChange(isNaN(parsed) ? null : parsed);
   };
 
+  // 초기화 핸들러
+  const handleReset = () => {
+    onChange(defaultBidPrice); // 현재가 + 최소 입찰 단위로 초기화
+  };
+
+  // 최소입찰단위의 배수로 버튼 생성
   const increaseButtons = [
-    { label: '+10만', amount: 100_000 },
-    { label: '+5만', amount: 50_000 },
-    { label: '+1만', amount: 10_000 },
-    { label: '+1천원', amount: 1_000 },
+    {
+      label: `+${formatToKoreanUnit(minBidUnit * 100)}`,
+      amount: minBidUnit * 100,
+      multiplier: '100배',
+    }, // 100배
+    {
+      label: `+${formatToKoreanUnit(minBidUnit * 50)}`,
+      amount: minBidUnit * 50,
+      multiplier: '50배',
+    }, // 50배
+    {
+      label: `+${formatToKoreanUnit(minBidUnit * 10)}`,
+      amount: minBidUnit * 10,
+      multiplier: '10배',
+    }, // 10배
+    { label: `+${formatToKoreanUnit(minBidUnit)}`, amount: minBidUnit, multiplier: '1배' }, // 1배
   ];
 
   const handleIncrease = (amount: number) => {
-    const current = bidPrice ?? currentPrice;
+    const current = bidPrice ?? defaultBidPrice; // 빈 값일 때 기본값 사용
     onChange(current + amount);
   };
 
@@ -61,11 +82,13 @@ const BidFormInput = ({
       <InputIcon
         id="price"
         type="number"
-        value={bidPrice ?? ''}
+        value={bidPrice ?? defaultBidPrice}
         label="희망입찰가"
         placeholder={placeholder}
         onChange={handleChange}
         minBidUnit={minBidUnit}
+        resetValue={defaultBidPrice} // 초기화할 값
+        onReset={handleReset} // 초기화 콜백
         className={validationError ? 'border-red-500' : ''}
       >
         <UserRound />
@@ -75,15 +98,17 @@ const BidFormInput = ({
       {validationError && <div className="mt-1 text-sm text-red-500">{validationError}</div>}
 
       <div className="grid grid-cols-4 gap-2 py-2">
-        {increaseButtons.map(({ label, amount }) => (
+        {increaseButtons.map(({ label, amount, multiplier }) => (
           <Button
             key={amount}
             size="min"
             color="secondary"
             type="button"
             onClick={() => handleIncrease(amount)}
+            className="flex h-auto flex-col items-center justify-center gap-0 px-2 py-1"
           >
-            {label}
+            <span>{label}</span>
+            <span className="text-xs opacity-70">({multiplier})</span>
           </Button>
         ))}
       </div>

--- a/apps/web/src/components/auction-detail/bid-form/input.tsx
+++ b/apps/web/src/components/auction-detail/bid-form/input.tsx
@@ -29,7 +29,7 @@ const BidFormInput = ({
   currentPrice,
   minUnit, // 최소 입찰 단위
   bidPrice,
-  // isBidInputOpen,
+  isBidInputOpen,
   onChange,
   validationError = '',
 }: ExtendedBidInputProps) => {
@@ -57,7 +57,7 @@ const BidFormInput = ({
   };
 
   return (
-    <div>
+    <div className={bidInputWrapper({ open: isBidInputOpen })}>
       <InputIcon
         id="price"
         type="number"

--- a/apps/web/src/components/auction-detail/container.tsx
+++ b/apps/web/src/components/auction-detail/container.tsx
@@ -109,7 +109,9 @@ const AuctionDetailContainer = () => {
           nickname={seller.nickname}
           profileImg={seller.profileImg ? seller.profileImg : '/avatar-female.svg'}
         >
-          <ButtonChat auctionId={auction.id} sellerId={auction.sellerId} />
+          {currentUser?.id !== auction.sellerId && (
+            <ButtonChat auctionId={auction.id} sellerId={auction.sellerId} />
+          )}
         </ProfileCard>
         <ItemSummary item={item} id={id as string} />
         <ItemDescription item={item} />

--- a/apps/web/src/components/auction-edit/form-edit.tsx
+++ b/apps/web/src/components/auction-edit/form-edit.tsx
@@ -69,6 +69,7 @@ const FormEdit = ({ itemId }: FormEditProps) => {
     })(),
     images:
       auction.auctionImages?.flatMap((image: { id: string; urls: string[] }) => image.urls) || [],
+    is_instant_buy_enabled: auction.auctionPrice?.isInstantBuyEnabled || false,
   };
 
   // 현재가 정보를 별도로 전달 (입찰 상태 포함)

--- a/apps/web/src/components/common/input/icon.tsx
+++ b/apps/web/src/components/common/input/icon.tsx
@@ -1,20 +1,36 @@
 import React from 'react';
 
+import { RotateCcw } from 'lucide-react';
+
+import { formatCurrency } from '@/lib/utils/price';
 interface InputIconProps extends React.HTMLProps<HTMLInputElement> {
   id: string;
   label?: string;
   children: React.ReactNode;
   minBidUnit?: number; // 입찰 단위
+  resetValue?: number; // 초기화할 값
+  onReset?: () => void; // 초기화 콜백
 }
 
-const InputIcon = ({ id, label, children, minBidUnit, ...props }: InputIconProps) => {
+const InputIcon = ({
+  id,
+  label,
+  children,
+  minBidUnit,
+  resetValue,
+  onReset,
+  value,
+  ...props
+}: InputIconProps) => {
+  const showResetButton =
+    resetValue !== undefined && onReset && value && Number(value) !== resetValue;
   return (
     <div className="flex w-full flex-col items-start justify-center gap-2">
       {label && (
         <label className="font-medium" htmlFor={id}>
           {label}{' '}
           <span className="text-xs text-neutral-500">
-            (입찰 단위: <strong>{minBidUnit || 1000}</strong>원)
+            (입찰 단위: <strong>{formatCurrency(minBidUnit || 0)}</strong>원)
           </span>
         </label>
       )}
@@ -23,11 +39,22 @@ const InputIcon = ({ id, label, children, minBidUnit, ...props }: InputIconProps
           {React.Children.toArray(children)[0]}
           <input
             id={id}
+            value={value}
             {...props}
             className="selection:bg-primary selection:text-primary-foreground file:text-foreground aria-invalid:ring-destructive/20 aria-invalid:border-destructive text-black file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-neutral-400 focus:shadow-none focus:outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
           />
         </div>
-        <div className="[&>button>svg]:h-5 [&>button>svg]:w-5 [&>svg]:h-5 [&>svg]:w-5">
+        <div className="h-[20px] [&>button>svg]:h-5 [&>button>svg]:w-5 [&>svg]:h-5 [&>svg]:w-5">
+          {showResetButton && (
+            <button
+              type="button"
+              onClick={onReset}
+              className="cursor-pointer transition-opacity hover:opacity-70"
+              title="현재가로 초기화"
+            >
+              <RotateCcw className="text-neutral-400" />
+            </button>
+          )}
           {React.Children.toArray(children)[1]}
         </div>
       </div>

--- a/apps/web/src/components/common/toast.tsx
+++ b/apps/web/src/components/common/toast.tsx
@@ -1,6 +1,6 @@
-// apps/web/src/components/common/toast.tsx
-
 'use client';
+
+import { useEffect, useRef, useState } from 'react';
 
 import { X } from 'lucide-react';
 
@@ -8,6 +8,65 @@ import { useToastStore } from '@/lib/zustand/store/toast-store';
 
 const Toast = () => {
   const { toasts, closeToast } = useToastStore();
+  const [visibleToasts, setVisibleToasts] = useState<string[]>([]);
+
+  const timersRef = useRef<Map<string, NodeJS.Timeout>>(new Map()); // 타이머 관리용 ref 추가
+
+  useEffect(() => {
+    const currentToastIds = toasts.map((toast) => toast.id);
+
+    // 새로 추가된 토스트 찾기
+    const newToastIds = currentToastIds.filter((id) => !visibleToasts.includes(id));
+
+    // 제거된 토스트의 타이머 정리
+    timersRef.current.forEach((timer, id) => {
+      if (!currentToastIds.includes(id)) {
+        clearTimeout(timer);
+        timersRef.current.delete(id);
+      }
+    });
+
+    if (newToastIds.length > 0) {
+      // 새 토스트 즉시 표시
+      setTimeout(() => {
+        setVisibleToasts((current) => [...current, ...newToastIds]);
+      }, 10);
+
+      // 각 새 토스트에 대해 3초 타이머 설정
+      newToastIds.forEach((id) => {
+        const timer = setTimeout(() => {
+          handleClose(id);
+        }, 3000);
+
+        timersRef.current.set(id, timer); // 타이머 저장
+      });
+    }
+
+    // 제거된 토스트는 visibleToasts에서도 제거
+    setVisibleToasts((prev) => prev.filter((id) => currentToastIds.includes(id)));
+  }, [toasts]);
+
+  // 컴포넌트 언마운트 시에만 정리하는 별도 useEffect 추가
+  useEffect(() => {
+    return () => {
+      timersRef.current.forEach((timer) => clearTimeout(timer));
+      timersRef.current.clear();
+    };
+  }, []);
+
+  const handleClose = (id: string) => {
+    // 타이머 정리
+    const timer = timersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
+
+    setVisibleToasts((prev) => prev.filter((toastId) => toastId !== id));
+    setTimeout(() => {
+      closeToast(id);
+    }, 300);
+  };
 
   const getToastStyles = (status: string) => {
     const styles = {
@@ -37,11 +96,14 @@ const Toast = () => {
     <div className="pointer-events-none fixed left-1/2 top-10 z-[9999] -translate-x-1/2 space-y-2">
       {toasts.map((toast) => {
         const styles = getToastStyles(toast.status);
+        const isVisible = visibleToasts.includes(toast.id);
 
         return (
           <div
             key={toast.id}
-            className={`pointer-events-auto flex w-96 items-center justify-between rounded-md px-4 py-3 ${styles.container} `}
+            className={`pointer-events-auto flex w-96 items-center justify-between rounded-md px-4 py-3 ${styles.container} transform transition-all duration-300 ease-out ${
+              isVisible ? 'translate-y-0 opacity-100' : '-translate-y-4 opacity-0'
+            }`}
           >
             <div className="flex-1">
               <div className={`text-sm font-semibold ${styles.title}`}>{toast.title}</div>
@@ -52,8 +114,8 @@ const Toast = () => {
 
             {toast.status !== 'notice' && (
               <button
-                onClick={() => closeToast(toast.id)}
-                className={`ml-3 flex h-7 w-7 items-center justify-center rounded-full transition-colors ${styles.closeBtn} `}
+                onClick={() => handleClose(toast.id)}
+                className={`ml-3 flex h-7 w-7 items-center justify-center rounded-full transition-all duration-200 hover:scale-110 active:scale-95 ${styles.closeBtn}`}
               >
                 <X size={14} />
               </button>

--- a/apps/web/src/hooks/auction/useEditAuction.tsx
+++ b/apps/web/src/hooks/auction/useEditAuction.tsx
@@ -52,7 +52,8 @@ const useEditAuction = (itemId: string) => {
             min_bid_unit: Number(formData.get('min_bid_unit') ?? 0),
           },
           end_time: String(formData.get('end_time') ?? ''),
-          images: [],
+          is_instant_buy_enabled: formData.get('is_instant_buy_enabled') === 'true',
+          is_extended_auction: formData.get('is_extended_auction') === 'true',
         };
 
         const result = createAuctionSchema.safeParse(rawData);
@@ -93,9 +94,24 @@ const useEditAuction = (itemId: string) => {
           finalImages = [...finalImages, ...newImageUrls];
         }
 
+        const startPrice = rawData.prices.start_price;
+
+        const phasedData = {
+          ...result.data,
+          is_instant_buy_enabled: rawData.is_instant_buy_enabled,
+          is_extended_auction: rawData.is_extended_auction,
+          prices: {
+            ...result.data.prices,
+            instant_price: rawData.is_instant_buy_enabled
+              ? Math.floor(startPrice * 1.2)
+              : undefined,
+          },
+          images: finalImages,
+        };
+
         console.log('🔄 서버액션 호출 시작...');
         // 서버 액션 호출
-        await updateAuction({ ...result.data, images: finalImages }, itemId);
+        await updateAuction(phasedData, itemId);
         console.log('✅ 서버액션 완료');
 
         // 경매 목록 관련 쿼리만 무효화 (상세 쿼리 제외)

--- a/apps/web/src/lib/utils/price.ts
+++ b/apps/web/src/lib/utils/price.ts
@@ -7,3 +7,27 @@ export const formatCurrency = (value: number | string): string => {
 export const formatCurrencyWithUnit = (value: number | string): string => {
   return `${formatCurrency(value)}원`;
 };
+
+// 한국어 단위 변환 (예) 10000 -> 1만, 100000000 -> 1억
+export const formatToKoreanUnit = (value: number): string => {
+  if (value >= 100000000) {
+    const billions = Math.floor(value / 100000000);
+    const remainder = value % 100000000;
+    if (remainder === 0) {
+      return `${billions}억원`;
+    } else {
+      const millions = Math.floor(remainder / 10000);
+      return `${billions}억${millions > 0 ? `${millions}만` : ''}원`;
+    }
+  } else if (value >= 10000) {
+    const tenThousands = Math.floor(value / 10000);
+    const remainder = value % 10000;
+    if (remainder === 0) {
+      return `${tenThousands}만원`;
+    } else {
+      return `${tenThousands}만${remainder.toLocaleString()}원`;
+    }
+  } else {
+    return `${value.toLocaleString()}원`;
+  }
+};

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -18,19 +18,20 @@ model User {
   isVerified      Boolean            @default(false) @map("is_verified")
   profileImg      String?            @map("profile_img")
   nickname        String             @unique @db.VarChar(50)
-  createdAt       DateTime           @default(now()) @map("created_at") @db.Timestamp(6)
-  updatedAt       DateTime?          @map("updated_at") @db.Timestamp(6)
+  createdAt       DateTime           @map("created_at") @db.Timestamptz(6)
+  updatedAt       DateTime?          @map("updated_at") @db.Timestamptz(6)
+  addresses       Address?
   alerts          Alert[]
   auctionItems    AuctionItem[]      @relation("SellerItems")
   bids            Bid[]
   chatMessages    ChatMessage[]
+  chat_room_reads chat_room_reads[]
   chatRoomsBuyer  ChatRoom[]         @relation("BuyerChatRooms")
   chatRoomsSeller ChatRoom[]         @relation("SellerChatRooms")
   favoriteItems   FavoriteItem[]
   locations       Location[]
   sales           Sale[]
   notifications   UserNotification[]
-  addresses       Address[]
 
   @@map("users")
 }
@@ -49,18 +50,17 @@ model Location {
 }
 
 model Address {
-  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  userId      String   @db.Uuid
-  label       String?  
-  userName    String?  
-  phone       String?  
-  address     String   
-  addressDetail    String?   
-  isPrimary   Boolean  @default(false)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-
-  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id            String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId        String    @unique @db.Uuid
+  label         String?   @default("Nullable")
+  userName      String?   @default("Not Null")
+  phone         String?   @default("Nullable")
+  address       String?   @default("Not Null")
+  addressDetail String?   @default("Nullable")
+  isPrimary     Boolean?  @default(false)
+  createdAt     DateTime? @default(now()) @db.Timestamptz(6)
+  updatedAt     DateTime? @default(now()) @updatedAt @db.Timestamptz(6)
+  user          User      @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
   @@map("addresses")
 }
@@ -72,7 +72,7 @@ model Alert {
   content       String?  @db.VarChar(255)
   alertCategory String?  @map("alert_category") @db.VarChar(50)
   isRead        Boolean  @default(false) @map("is_read")
-  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamp(6)
+  createdAt     DateTime @map("created_at") @db.Timestamptz(6)
   user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("alerts")
@@ -82,7 +82,7 @@ model FavoriteItem {
   id        String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   userId    String      @map("user_id") @db.Uuid
   itemId    String      @map("item_id") @db.Uuid
-  createdAt DateTime    @default(now()) @map("created_at") @db.Timestamp(6)
+  createdAt DateTime    @map("created_at") @db.Timestamptz(6)
   item      AuctionItem @relation(fields: [itemId], references: [id], onDelete: Cascade)
   user      User        @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -106,11 +106,11 @@ model AuctionItem {
   description   String?
   categoryId    String         @map("category_id") @db.Uuid
   locationId    String?        @map("location_id") @db.Uuid
-  startTime     DateTime?      @map("start_time") @db.Timestamp(6)
-  endTime       DateTime       @map("end_time") @db.Timestamp(6)
+  startTime     DateTime?      @map("start_time") @db.Timestamptz(6)
+  endTime       DateTime       @map("end_time") @db.Timestamptz(6)
   status        String         @default("ACTIVE") @db.VarChar(20)
   thumbnailUrl  String?        @map("thumbnail_url")
-  createdAt     DateTime       @map("created_at") @db.Timestamp(6)
+  createdAt     DateTime       @map("created_at") @db.Timestamptz(6)
   auctionImages AuctionImage[]
   category      Category       @relation(fields: [categoryId], references: [id])
   location      Location?      @relation(fields: [locationId], references: [id], onDelete: Restrict)
@@ -143,7 +143,7 @@ model Bid {
   itemId    String      @map("item_id") @db.Uuid
   bidderId  String      @map("bidder_id") @db.Uuid
   price     Int
-  createdAt DateTime    @default(now()) @map("created_at") @db.Timestamp(6)
+  createdAt DateTime    @map("created_at") @db.Timestamptz(6)
   bidder    User        @relation(fields: [bidderId], references: [id], onDelete: Cascade)
   item      AuctionItem @relation(fields: [itemId], references: [id], onDelete: Cascade)
 
@@ -166,7 +166,7 @@ model Sale {
   finalPrice    Int         @map("final_price")
   paymentStatus String      @map("payment_status") @db.VarChar(50)
   result        String      @db.VarChar(50)
-  createdAt     DateTime    @map("created_at") @db.Timestamp(6)
+  createdAt     DateTime    @map("created_at") @db.Timestamptz(6)
   buyer         User        @relation(fields: [buyerId], references: [id], onDelete: Cascade)
   item          AuctionItem @relation(fields: [itemId], references: [id], onDelete: Cascade)
 
@@ -174,30 +174,33 @@ model Sale {
 }
 
 model ChatRoom {
-  id            String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  auctionId     String        @map("auction_id") @db.Uuid
-  sellerId      String        @map("seller_id") @db.Uuid
-  buyerId       String        @map("buyer_id") @db.Uuid
-  createdAt     DateTime      @map("created_at") @db.Timestamp(6)
-  lastMessageAt DateTime?     @map("last_message_at") @db.Timestamp(6)
-  isDeleted     Boolean       @default(false) @map("is_deleted")
-  messages      ChatMessage[]
-  auction       AuctionItem   @relation(fields: [auctionId], references: [id], onDelete: Cascade)
-  buyer         User          @relation("BuyerChatRooms", fields: [buyerId], references: [id], onDelete: Cascade)
-  seller        User          @relation("SellerChatRooms", fields: [sellerId], references: [id], onDelete: Cascade)
+  id              String            @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  auctionId       String            @map("auction_id") @db.Uuid
+  sellerId        String            @map("seller_id") @db.Uuid
+  buyerId         String            @map("buyer_id") @db.Uuid
+  createdAt       DateTime          @map("created_at") @db.Timestamptz(6)
+  isDeleted       Boolean           @default(false) @map("is_deleted")
+  lastMessageAt   DateTime?         @map("last_message_at") @db.Timestamptz(6)
+  last_message_id String?           @db.Uuid
+  messages        ChatMessage[]
+  chat_room_reads chat_room_reads[]
+  auction         AuctionItem       @relation(fields: [auctionId], references: [id], onDelete: Cascade)
+  buyer           User              @relation("BuyerChatRooms", fields: [buyerId], references: [id], onDelete: Cascade)
+  seller          User              @relation("SellerChatRooms", fields: [sellerId], references: [id], onDelete: Cascade)
 
   @@map("chat_rooms")
 }
 
 model ChatMessage {
-  id       String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  roomId   String   @map("room_id") @db.Uuid
-  senderId String   @map("sender_id") @db.Uuid
-  content  String?
-  imageUrl String?  @map("image_url")
-  sentAt   DateTime @map("sent_at") @db.Timestamp(6)
-  room     ChatRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
-  sender   User     @relation(fields: [senderId], references: [id], onDelete: Cascade)
+  id              String            @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  roomId          String            @map("room_id") @db.Uuid
+  senderId        String            @map("sender_id") @db.Uuid
+  content         String?
+  sentAt          DateTime          @map("sent_at") @db.Timestamptz(6)
+  type            String            @default("common")
+  room            ChatRoom          @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  sender          User              @relation(fields: [senderId], references: [id], onDelete: Cascade)
+  chat_room_reads chat_room_reads[]
 
   @@map("chat_messages")
 }
@@ -210,10 +213,35 @@ model UserNotification {
   deviceInfo       String?  @map("device_info") @db.VarChar(255)
   platform         String?  @db.VarChar(20)
   isActive         Boolean  @default(true) @map("is_active")
-  createdAt        DateTime @default(now()) @map("created_at") @db.Timestamp(6)
-  updatedAt        DateTime @updatedAt @map("updated_at") @db.Timestamp(6)
+  createdAt        DateTime @map("created_at") @db.Timestamptz(6)
+  updatedAt        DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
   user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, notificationType])
   @@map("user_notifications")
+}
+
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model accounts {
+  id            BigInt    @id @default(autoincrement())
+  userId        String?   @default("Not Null")
+  bankName      String?   @default("Not Null")
+  accountNumber String?   @default("Not Null")
+  holderName    String?   @default("Not Null")
+  isPrimary     Boolean?  @default(false)
+  created_at    DateTime? @default(now()) @db.Timestamptz(6)
+  updated_at    DateTime? @db.Timestamptz(6)
+}
+
+model chat_room_reads {
+  room_id              String      @db.Uuid
+  user_id              String      @db.Uuid
+  last_read_message_id String      @db.Uuid
+  updated_at           DateTime    @default(now()) @db.Timestamptz(6)
+  last_read_at         DateTime?   @db.Timestamptz(6)
+  chat_messages        ChatMessage @relation(fields: [last_read_message_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  chat_rooms           ChatRoom    @relation(fields: [room_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  users                User        @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@id([room_id, user_id])
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -82,7 +82,7 @@ model FavoriteItem {
   id        String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   userId    String      @map("user_id") @db.Uuid
   itemId    String      @map("item_id") @db.Uuid
-  createdAt DateTime    @map("created_at") @db.Timestamptz(6)
+  createdAt DateTime    @default(now()) @map("created_at") @db.Timestamptz(6)
   item      AuctionItem @relation(fields: [itemId], references: [id], onDelete: Cascade)
   user      User        @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -143,7 +143,7 @@ model Bid {
   itemId    String      @map("item_id") @db.Uuid
   bidderId  String      @map("bidder_id") @db.Uuid
   price     Int
-  createdAt DateTime    @map("created_at") @db.Timestamptz(6)
+  createdAt DateTime    @default(now()) @map("created_at") @db.Timestamptz(6)
   bidder    User        @relation(fields: [bidderId], references: [id], onDelete: Cascade)
   item      AuctionItem @relation(fields: [itemId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
closes #370 
## 📋 작업 내용


- bidform 모달/닫기 살리기
- bidtable 내가 입찰 시 최신 입찰가로 업데이트
- 경매상세 내가 올린 아이템 페이지에는 채팅버튼 안보이게
- 입찰가 입력창에 초기화 버튼 추가
- 초기화 버튼 클릭하면 현재입찰가+입찰단가로 세팅
- 기본값도 현재입찰가+입찰단가로 세팅
- 내가 올린 경매아이템은 입찰하기 불가능
- 입찰금 추가버튼 유틸함수 생성 및 적용(1배,10배,50배,100배)
- 경매 수정 시 즉시구매 설정 유지 및 반영
- Supabase에서 timestamptz로 변경 후 Prisma에서 변경사항 pull, 스키마 동기화 

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

경매 상세 페이지 및 관련 흐름을 개선합니다. 즉시 구매 기능을 추가하고, 입찰 양식 UI를 개편하며, 토스트 알림을 업그레이드하고, 전체 주소 관리 양식을 통합합니다. 이와 함께 설정 및 지원 페이지의 기본 구조를 마련합니다.

새로운 기능:
- 스키마 지원 및 직거래 채팅 내비게이션을 포함한 경매 생성 및 상세 흐름에 즉시 구매 옵션을 도입합니다.
- 유효성 검사가 적용된 동적 주소 양식을 생성/편집 페이지에 추가하고, 주소 CRUD 훅 및 토스트 피드백을 통합합니다.

개선 사항:
- 토글 가능한 입력, 기본값/초기화 제어, 한국어 단위 레이블이 있는 배수 버튼, 애니메이션 및 자가 입찰 방지 기능을 포함하여 입찰 양식 UI를 전면 개편합니다.
- 슬라이드/페이드 전환, 자동 닫기 타이머 및 향상된 닫기 버튼 UX를 통해 토스트 컴포넌트를 개선합니다.
- 전용 레이아웃과 헤더를 포함한 플레이스홀더 설정 및 지원 페이지를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the auction detail page and related flows by adding instant-buy functionality, revamping the bid form UI, upgrading toast notifications, and integrating a full address management form, along with scaffolding settings and support pages.

New Features:
- Introduce instant purchase option in auction creation and detail flows including schema support and direct-deal chat navigation
- Add dynamic address form on create/edit pages with validation and integrate address CRUD hooks and toast feedback

Enhancements:
- Overhaul bid form UI with toggleable input, default/reset controls, multiplier buttons with Korean unit labels, animations, and self-bid prevention
- Improve toast component with slide/fade transitions, auto-close timers, and enhanced close-button UX
- Add placeholder settings and support pages with dedicated layouts and headers

</details>