### PR TITLE
[fix] 채팅방 Input 자동 포커싱

### DIFF
--- a/apps/web/src/components/chat/input/input-form.tsx
+++ b/apps/web/src/components/chat/input/input-form.tsx
@@ -7,6 +7,7 @@ import { SendHorizontal } from 'lucide-react';
 import { Button, Textarea } from '@/components/ui';
 
 import { supabase } from '@/lib/supabase/client';
+import { useToastStore } from '@/lib/zustand/store/toast-store';
 import { useUserStore } from '@/lib/zustand/store/user-store';
 
 const InputForm = ({ roomId }: { roomId: string }) => {
@@ -15,6 +16,7 @@ const InputForm = ({ roomId }: { roomId: string }) => {
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const currentUserId = useUserStore((state) => state.user?.id);
+  const { showToast } = useToastStore();
 
   const sendMessage = async () => {
     if (!newMessage.trim() || isSending) return;
@@ -29,14 +31,17 @@ const InputForm = ({ roomId }: { roomId: string }) => {
       });
 
       if (error) {
-        console.error('메시지 전송 에러:', error);
-        alert('메시지 전송에 실패했습니다.');
-        return;
+        throw new Error();
       }
 
       setNewMessage('');
     } catch (error) {
-      alert('메시지 전송에 실패했습니다.');
+      showToast({
+        status: 'error',
+        title: '메세지 전송에 실패했습니다.',
+        subtext: '메세지 전송에 실패했습니다. 잠시 후 다시 시도해주세요.',
+        autoClose: true,
+      });
     } finally {
       setIsSending(false);
       inputRef.current?.focus();

--- a/apps/web/src/components/chat/input/input-form.tsx
+++ b/apps/web/src/components/chat/input/input-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { SendHorizontal } from 'lucide-react';
 
@@ -9,9 +9,10 @@ import { Button, Textarea } from '@/components/ui';
 import { supabase } from '@/lib/supabase/client';
 import { useUserStore } from '@/lib/zustand/store/user-store';
 
-const InputForm = (roomId: { roomId: string }) => {
+const InputForm = ({ roomId }: { roomId: string }) => {
   const [newMessage, setNewMessage] = useState('');
   const [isSending, setIsSending] = useState(false);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const currentUserId = useUserStore((state) => state.user?.id);
 
@@ -21,7 +22,7 @@ const InputForm = (roomId: { roomId: string }) => {
     setIsSending(true);
     try {
       const { error } = await supabase.from('chat_messages').insert({
-        room_id: roomId.roomId,
+        room_id: roomId,
         sender_id: currentUserId,
         content: newMessage.trim(),
         sent_at: new Date().toISOString(),
@@ -35,10 +36,10 @@ const InputForm = (roomId: { roomId: string }) => {
 
       setNewMessage('');
     } catch (error) {
-      console.error('메시지 전송 실패:', error);
       alert('메시지 전송에 실패했습니다.');
     } finally {
       setIsSending(false);
+      inputRef.current?.focus();
     }
   };
 
@@ -52,12 +53,12 @@ const InputForm = (roomId: { roomId: string }) => {
   return (
     <div className="my-4 flex w-full flex-row items-stretch gap-2 overflow-x-hidden">
       <Textarea
+        ref={inputRef}
         variant="chat"
         placeholder="메세지를 입력하세요. "
         onKeyDown={handleKeyDown}
         value={newMessage}
         onChange={(e) => setNewMessage(e.target.value)}
-        disabled={isSending}
       />
       <Button
         variant="solid"

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -33,5 +33,6 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     );
   }
 );
+Textarea.displayName = 'Textarea';
 
 export { Textarea };

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -21,14 +21,17 @@ const textareaStyles = cva(
 
 type TextareaProps = React.ComponentProps<'textarea'> & VariantProps<typeof textareaStyles>;
 
-const Textarea = ({ className, variant, ...props }: TextareaProps) => {
-  return (
-    <textarea
-      data-slot="textarea"
-      className={cn(textareaStyles({ variant, class: className }))}
-      {...props}
-    />
-  );
-};
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, variant, ...props }, ref) => {
+    return (
+      <textarea
+        data-slot="textarea"
+        ref={ref}
+        className={cn(textareaStyles({ variant, class: className }))}
+        {...props}
+      />
+    );
+  }
+);
 
 export { Textarea };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
closes #354 

- 채팅방 전송 후에도 input 포커싱 유지
- 메세지 전송 실패 시 toast 표시

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷


## 📄 기타

## Sourcery 요약

메시지 전송 후 채팅 입력창의 포커스를 유지하고, 경고창 기반 오류를 토스트 알림으로 교체하며, Textarea 컴포넌트가 ref 포워딩을 지원하도록 리팩토링했습니다.

Bug Fixes:
- 메시지 전송 후 채팅 입력창에 포커스 유지
- 메시지 전송 실패 시 경고창 대신 오류 토스트 표시

Enhancements:
- 외부 포커스 제어를 위해 Textarea 컴포넌트가 ref를 전달하도록 리팩토링
- 향상된 상태 관리를 위해 InputForm에서 useRef 및 zustand 토스트 스토어 사용

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Maintain chat input focus after sending messages and replace alert-based errors with toast notifications, refactoring Textarea to support ref forwarding.

Bug Fixes:
- Retain focus on the chat input after a message is sent
- Show an error toast on message send failure instead of an alert

Enhancements:
- Refactor Textarea component to forward refs for external focus control
- Use useRef and zustand toast store in InputForm for improved state management

</details>