### PR TITLE
[fix] Sentry 405 에러 해결을 위한 터널링 설정 추가

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -4,6 +4,9 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: 'https://9c0dac06d753dcc69a188ba9e75ef840@o4509634509471744.ingest.us.sentry.io/4509634513928192',
 
+  // 터널링 추가
+  tunnel: '/monitoring',
+
   // 로그 활성화
   _experiments: {
     enableLogs: true,

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -7,6 +7,9 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: 'https://9c0dac06d753dcc69a188ba9e75ef840@o4509634509471744.ingest.us.sentry.io/4509634513928192',
 
+  // 터널링 추가
+  tunnel: '/monitoring',
+
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

문제발생
- 브라우저 콘솔에서 `POST /auth/signin 405 Method Not Allowed` 에러 발생
- Sentry 모니터링 요청이 NextAuth 라우트와 충돌하여 실패

해결방법
- Sentry 클라이언트/서버 설정에 `tunnel: '/monitoring'` 옵션 추가
- next.config.ts의 `tunnelRoute: '/monitoring'` 설정 활용
- Sentry 요청을 별도 터널 라우트로 우회하여 충돌 방지

방법적용
- `sentry.client.config.ts`: tunnel 옵션 추가
- `sentry.server.config.ts`: tunnel 옵션 추가

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

Sentry 이벤트를 사용자 지정 터널 엔드포인트를 통해 라우팅하여 모니터링 요청이 NextAuth 경로와 충돌하는 것을 방지하고 405 오류를 일으키는 것을 막습니다.

버그 수정:
- NextAuth 로그인 경로에서 Sentry 모니터링 요청이 405 Method Not Allowed 오류를 유발하는 것을 방지합니다.

개선 사항:
- 별도의 엔드포인트를 통해 이벤트를 프록시하도록 Sentry 클라이언트 및 서버 구성 모두에 'tunnel: "/monitoring"' 설정을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route Sentry events through a custom tunnel endpoint to prevent monitoring requests from colliding with NextAuth routes and causing 405 errors.

Bug Fixes:
- Prevent Sentry monitoring requests from triggering 405 Method Not Allowed errors on the NextAuth sign-in route.

Enhancements:
- Add 'tunnel: "/monitoring"' setting to both Sentry client and server configurations to proxy events through a separate endpoint.

</details>