### PR TITLE
[feat] chatListCard skeleton 처리

### DIFF
--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ChatListCard } from '@/components/chat';
-import ChatListCardSkeleton from '@/components/chat/chat-list-card-skeleton';
+import { ChatListCardSkeleton } from '@/components/chat';
 import { FilterTab } from '@/components/common';
 
 import { useChatRooms } from '@/hooks/chat/useChatRoom';

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ChatListCard } from '@/components/chat';
+import ChatListCardSkeleton from '@/components/chat/chat-list-card-skeleton';
 import { FilterTab } from '@/components/common';
 
 import { useChatRooms } from '@/hooks/chat/useChatRoom';
@@ -8,12 +9,13 @@ import { useChatRooms } from '@/hooks/chat/useChatRoom';
 import { CHAT_STATUS } from '@/lib/constants/chat';
 
 const Page = () => {
-  const { chatRooms, isLoading, error, total } = useChatRooms();
+  const { chatRooms, isLoading, error } = useChatRooms();
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-8">
-        <div className="text-gray-500">채팅방 목록을 불러오는 중...</div>
+      <div className="flex h-full w-full flex-col px-4">
+        <FilterTab filterKey={'chatStatus'} items={CHAT_STATUS} />
+        <ChatListCardSkeleton />
       </div>
     );
   }
@@ -25,17 +27,15 @@ const Page = () => {
       </div>
     );
   }
-  if (!chatRooms.length) {
-    return (
-      <div className="flex items-center justify-center py-8">
-        <div className="text-gray-500">대화 중인 채팅방이 없습니다</div>
-      </div>
-    );
-  }
 
   return (
     <div className="flex h-full w-full flex-col px-4">
       <FilterTab filterKey={'chatStatus'} items={CHAT_STATUS} />
+      {!chatRooms.length && (
+        <div className="flex items-center justify-center py-8">
+          <div className="text-gray-500">대화 중인 채팅방이 없습니다</div>
+        </div>
+      )}
       {chatRooms.map((chat) => {
         return <ChatListCard key={chat.id} chatInfo={chat} />;
       })}

--- a/apps/web/src/components/chat/chat-list-card-skeleton.tsx
+++ b/apps/web/src/components/chat/chat-list-card-skeleton.tsx
@@ -1,0 +1,30 @@
+const ChatListCardSkeleton = () => {
+  return (
+    <div className="flex-1">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div
+          key={`skeleton-${index}`}
+          className="flex h-fit w-full items-center justify-between gap-2.5"
+        >
+          <div className="flex w-full shrink items-center gap-2.5 py-1">
+            {/* Thumbnail skeleton */}
+            <div className="w-15 h-15 shrink-0 animate-pulse rounded-lg bg-gray-200" />
+
+            <div className="flex w-full shrink flex-col">
+              <div>
+                <p className="flex items-center gap-2">
+                  {/* Nickname skeleton */}
+                  <span className="h-5 w-20 animate-pulse rounded bg-gray-200" />
+                </p>
+              </div>
+              {/* Message content skeleton */}
+              <div className="text-min mt-1 h-6 w-2/3 animate-pulse rounded bg-gray-200" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ChatListCardSkeleton;

--- a/apps/web/src/components/chat/index.ts
+++ b/apps/web/src/components/chat/index.ts
@@ -12,4 +12,5 @@ export { default as DateMessage } from './messages/date-message';
 export { default as ChatContainer } from './messages/chat-container';
 
 export { default as ChatListCard } from './chat-list-card';
+export { default as ChatListCardSkeleton } from './chat-list-card-skeleton';
 export { default as ProductInfoCard } from './product-info-card';


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #395 

## 📋 작업 내용

- chatListCard skeleton 생성
- isLoading 상태일 때 호출

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 제공 요약

채팅 목록 카드에 스켈레톤 로딩 UI를 도입하고, 데이터 로딩 중일 때 채팅 페이지에 필터 탭과 스켈레톤 플레이스홀더를 함께 표시하도록 업데이트하며, 빈 상태 렌더링을 통합합니다.

새로운 기능:
- 플레이스홀더 카드 렌더링을 위한 `ChatListCardSkeleton` 컴포넌트 추가
- 채팅방 로딩 상태 동안 스켈레톤 플레이스홀더와 필터 탭 표시

개선 사항:
- 별도의 조건부 블록 대신 메인 채팅 목록 JSX에 빈 상태 렌더링 통합
- `useChatRooms` 훅 응답에서 사용되지 않는 `total` 속성 제거

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a skeleton loading UI for chat list cards and update the Chat page to show the filter tab alongside skeleton placeholders when data is loading while consolidating the empty state rendering

New Features:
- Add ChatListCardSkeleton component to render placeholder cards
- Display skeleton placeholders and the filter tab during chat rooms loading state

Enhancements:
- Integrate empty state rendering into the main chat list JSX instead of a separate conditional block
- Remove unused total property from useChatRooms hook response

</details>