### PR TITLE
[fix] 프로필 페이지 인증 처리 및 동적 렌더링 설정

### DIFF
--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { redirect } from 'next/navigation';
 
 import { Pen } from 'lucide-react';
 
@@ -10,45 +11,38 @@ import { getMyProfile } from '@/lib/actions/profile';
 
 export const dynamic = 'force-dynamic';
 const ProfilePage = async () => {
-  try {
-    const profile = await getMyProfile();
-    return (
-      <main className={`h-full overflow-auto bg-white`}>
-        <div className="height-auto w-full bg-white">
-          {/* Profile Card */}
-          <div className="border-b-4 border-neutral-200">
-            <ProfileCard
-              nickname={profile.nickname || '사용자'}
-              profileImg={profile.profileImg || '/avatar-male.svg'}
-            >
-              <Link href="/profile/edit">
-                <Button variant="outline" size={'sm'}>
-                  <Pen />
-                  프로필수정
-                </Button>
-              </Link>
-            </ProfileCard>
-          </div>
-
-          {/* Menu List */}
-          <div className="mt-8 px-6">
-            <MenuList />
-          </div>
-
-          <LogoutButton />
-        </div>
-      </main>
-    );
-  } catch (error) {
-    console.error('프로필 페이지 로드 중 오류:', error);
-
-    const errorMessage = error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.';
-    return (
-      <div className="flex h-96 items-center justify-center">
-        <p>프로필을 불러올 수 없습니다: {errorMessage}</p>
-      </div>
-    );
+  const profile = await getMyProfile();
+  // 프로필이 없으면 (로그인하지 않았거나 에러) 로그인 페이지로 리다이렉트
+  if (!profile) {
+    redirect('/auth/signin?redirectTo=/profile');
   }
+  return (
+    <main className={`h-full overflow-auto bg-white`}>
+      <div className="height-auto w-full bg-white">
+        {/* Profile Card */}
+        <div className="border-b-4 border-neutral-200">
+          <ProfileCard
+            nickname={profile.nickname || '사용자'}
+            profileImg={profile.profileImg || '/avatar-male.svg'}
+          >
+            <Link href="/profile/edit">
+              <Button variant="outline" size={'sm'}>
+                <Pen />
+                프로필수정
+              </Button>
+            </Link>
+          </ProfileCard>
+        </div>
+
+        {/* Menu List */}
+        <div className="mt-8 px-6">
+          <MenuList />
+        </div>
+
+        <LogoutButton />
+      </div>
+    </main>
+  );
 };
 
 export default ProfilePage;

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -5,7 +5,7 @@ Sentry.init({
   dsn: 'https://9c0dac06d753dcc69a188ba9e75ef840@o4509634509471744.ingest.us.sentry.io/4509634513928192',
 
   // 터널링 추가
-  tunnel: '/monitoring',
+  tunnel: '/api/monitoring',
 
   // 로그 활성화
   _experiments: {

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -8,7 +8,7 @@ Sentry.init({
   dsn: 'https://9c0dac06d753dcc69a188ba9e75ef840@o4509634509471744.ingest.us.sentry.io/4509634513928192',
 
   // 터널링 추가
-  tunnel: '/monitoring',
+  tunnel: '/api/monitoring',
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/apps/web/src/lib/actions/profile.ts
+++ b/apps/web/src/lib/actions/profile.ts
@@ -9,20 +9,19 @@ import { getCurrentUser } from '@/lib/utils/auth-server';
 
 export const getMyProfile = async () => {
   try {
-    // 현재 인증된 사용자 가져오기
     const user = await getCurrentUser();
     if (!user) {
-      throw new Error('로그인이 필요합니다.');
+      return null;
     }
-    // 사용자 ID를 사용하여 프로필 조회
-    const profile = await getUserProfileFromDB(user.id); // DB에서 프로필 조회
+
+    const profile = await getUserProfileFromDB(user.id);
     if (!profile) {
       throw new Error('프로필을 찾을 수 없습니다.');
     }
     return profile;
   } catch (error) {
     console.error('내 프로필 조회 에러:', error);
-    throw new Error('내 프로필 조회 실패');
+    return null;
   }
 };
 

--- a/apps/web/src/lib/utils/auth-server.ts
+++ b/apps/web/src/lib/utils/auth-server.ts
@@ -9,14 +9,22 @@ export const getCurrentUser = async () => {
       error,
     } = await supabase.auth.getUser();
 
+    // AuthSessionMissingError는 정상적인 상황 (로그인하지 않은 사용자)
+    if (error?.message === 'Auth session missing!') {
+      return null;
+    }
+
     if (error) {
       console.error('사용자 정보 조회 에러:', error);
       return null;
     }
 
     return user;
-  } catch (error) {
-    console.error('사용자 정보 조회 예외:', error);
+  } catch (error: any) {
+    // AuthSessionMissingError는 로그 출력하지 않음
+    if (error?.message !== 'Auth session missing!') {
+      console.error('사용자 정보 조회 예외:', error);
+    }
     return null;
   }
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
closes #398 
## 📋 작업 내용

+ sentry 터널링 경로 /api/monitoring 로 수정

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

인증되지 않은 사용자를 프로필 페이지에서 리디렉션하여 인증을 강화하고, 세션 처리 유틸리티를 표준화하여 세션 누락 또는 오류 시 null을 반환하도록 하며, Sentry의 터널 엔드포인트를 업데이트합니다.

개선 사항:
- 프로필 페이지에서 인증되지 않은 사용자를 로그인 흐름으로 리디렉션합니다.
- `getCurrentUser` 및 `getMyProfile`을 수정하여 세션 누락 또는 오류 시 null을 반환하고, `AuthSessionMissingError` 로그를 억제합니다.
- Sentry 구성을 업데이트하여 `/api/monitoring`을 터널 엔드포인트로 사용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce authentication on the profile page by redirecting unauthenticated users, standardize session-handling utilities to return null for missing sessions or errors, and update Sentry’s tunnel endpoint

Enhancements:
- Redirect unauthenticated users from the profile page to the sign-in flow
- Modify getCurrentUser and getMyProfile to return null for missing sessions or errors and suppress AuthSessionMissingError logs
- Update Sentry configuration to use '/api/monitoring' as the tunnel endpoint

</details>