### PR TITLE
[feat] 채팅방 경매 상태 종료 시 안내 플로우 

### DIFF
--- a/apps/web/app/chat/[id]/page.tsx
+++ b/apps/web/app/chat/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { ChatContainer, ChatInputBar, ProductInfoCard } from '@/components/chat';
 
+import { getAuctionStatus } from '@/lib/actions/auction';
+
 const Page = async ({
   params,
   searchParams,
@@ -12,9 +14,11 @@ const Page = async ({
 
   const roomId = id;
 
+  const status = await getAuctionStatus(auctionId);
+
   return (
     <div className="flex h-full w-full flex-col justify-between">
-      <ProductInfoCard auctionId={auctionId} />
+      <ProductInfoCard auctionId={auctionId} status={status} />
       <ChatContainer roomId={roomId} />
       <ChatInputBar roomId={roomId} />
     </div>

--- a/apps/web/src/components/chat/index.ts
+++ b/apps/web/src/components/chat/index.ts
@@ -14,3 +14,4 @@ export { default as ChatContainer } from './messages/chat-container';
 export { default as ChatListCard } from './chat-list-card';
 export { default as ChatListCardSkeleton } from './chat-list-card-skeleton';
 export { default as ProductInfoCard } from './product-info-card';
+export { default as ProductCardSkeleton } from './product-card-skeleton';

--- a/apps/web/src/components/chat/product-card-error.tsx
+++ b/apps/web/src/components/chat/product-card-error.tsx
@@ -1,0 +1,23 @@
+import productCardStyle from '@/components/chat/style';
+import { Button } from '@/components/ui';
+
+const ProductCardError = ({ onClick }: { onClick: () => void }) => {
+  return (
+    <div className={productCardStyle().wrapper()}>
+      <div className={productCardStyle().content({ loading: true })}>
+        <div className="h-12 w-12 rounded-md bg-neutral-200" />
+        <div className={productCardStyle().infoBox()}>
+          <div className="mb-2 h-4 w-3/4 rounded bg-neutral-200" />
+          <div className="h-3 w-1/2 rounded bg-neutral-200" />
+        </div>
+      </div>
+      <div className={productCardStyle().buttonBox()}>
+        <Button variant="outline" color="primary" size="min" onClick={onClick} className="w-1/5">
+          다시 시도
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ProductCardError;

--- a/apps/web/src/components/chat/product-card-skeleton.tsx
+++ b/apps/web/src/components/chat/product-card-skeleton.tsx
@@ -1,0 +1,21 @@
+import productCardStyle from '@/components/chat/style';
+
+const ProductCardSkeleton = () => {
+  return (
+    <div className={productCardStyle().wrapper({ loading: true })}>
+      <div className={productCardStyle().content()}>
+        <div className="h-12 w-12 rounded-md bg-neutral-200"></div>
+        <div className={productCardStyle().infoBox()}>
+          <div className="mb-2 h-4 w-3/4 rounded bg-neutral-200"></div>
+          <div className="h-3 w-1/2 rounded bg-neutral-200"></div>
+        </div>
+      </div>
+      <div className={productCardStyle().buttonBox()}>
+        <div className="font-weight-semibold h-8 w-1/5 rounded-md bg-neutral-200 px-3 text-sm"></div>
+        <div className="font-weight-semibold h-8 w-1/5 rounded-md bg-neutral-200 px-3 text-sm"></div>
+      </div>
+    </div>
+  );
+};
+
+export default ProductCardSkeleton;

--- a/apps/web/src/components/chat/product-card-skeleton.tsx
+++ b/apps/web/src/components/chat/product-card-skeleton.tsx
@@ -4,15 +4,11 @@ const ProductCardSkeleton = () => {
   return (
     <div className={productCardStyle().wrapper({ loading: true })}>
       <div className={productCardStyle().content()}>
-        <div className="h-12 w-12 rounded-md bg-neutral-200"></div>
+        <div className="h-12 w-12 rounded-md bg-neutral-200" />
         <div className={productCardStyle().infoBox()}>
-          <div className="mb-2 h-4 w-3/4 rounded bg-neutral-200"></div>
-          <div className="h-3 w-1/2 rounded bg-neutral-200"></div>
+          <div className="mb-2 h-4 w-3/4 rounded bg-neutral-200" />
+          <div className="h-3 w-1/2 rounded bg-neutral-200" />
         </div>
-      </div>
-      <div className={productCardStyle().buttonBox()}>
-        <div className="font-weight-semibold h-8 w-1/5 rounded-md bg-neutral-200 px-3 text-sm"></div>
-        <div className="font-weight-semibold h-8 w-1/5 rounded-md bg-neutral-200 px-3 text-sm"></div>
       </div>
     </div>
   );

--- a/apps/web/src/components/chat/product-info-card.tsx
+++ b/apps/web/src/components/chat/product-info-card.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 
 import { ProductCardSkeleton } from '@/components/chat';
+import ProductCardError from '@/components/chat/product-card-error';
 import productCardStyle from '@/components/chat/style';
 import { Button } from '@/components/ui';
 import Thumbnail from '@/components/ui/thumbnail';
@@ -66,19 +67,7 @@ const ProductInfoCard = ({ auctionId, status }: ProductInfoCardProps) => {
       autoClose: true,
     });
 
-    return (
-      <div className={productCardStyle().wrapper()}>
-        <Button
-          variant="outline"
-          color={color}
-          size="min"
-          onClick={() => refetchAuction()}
-          className="w-1/5"
-        >
-          다시 시도
-        </Button>
-      </div>
-    );
+    return <ProductCardError onClick={() => refetchAuction()} />;
   }
 
   return (

--- a/apps/web/src/components/chat/product-info-card.tsx
+++ b/apps/web/src/components/chat/product-info-card.tsx
@@ -51,6 +51,14 @@ const ProductInfoCard = ({ auctionId, status }: ProductInfoCardProps) => {
   const color = isDone ? 'disabled' : 'primary';
 
   const handleComplete = () => {
+    showToast({
+      status: 'success',
+      title: '거래 종료!',
+      subtext:
+        '거래가 종료되었습니다. 공유하신 주소와 계좌에 대한 메세지는 더 이상 보여지지 않습니다.',
+      autoClose: true,
+    });
+
     setIsDone(true);
     updateAuctionStatus(auctionId, 'COMPLETED');
   };
@@ -93,6 +101,7 @@ const ProductInfoCard = ({ auctionId, status }: ProductInfoCardProps) => {
           color={color}
           size="min"
           onClick={() => refetchCurrentPrice()}
+          disabled={isDone}
           className="w-1/5"
         >
           새로고침

--- a/apps/web/src/components/chat/product-info-card.tsx
+++ b/apps/web/src/components/chat/product-info-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import ProductCardSkeleton from '@/components/chat/product-card-skeleton';
 import productCardStyle from '@/components/chat/style';
 import { Button } from '@/components/ui';
 import Thumbnail from '@/components/ui/thumbnail';
@@ -10,10 +11,22 @@ import { useCurrentPrice } from '@/hooks/auction/useCurrentPrice';
 import { useAuctionDetail } from '@/hooks/queries/auction';
 import { useBidsByAuction } from '@/hooks/queries/bids';
 
+import { updateAuctionStatus } from '@/lib/actions/auction';
 import { formatCurrencyWithUnit } from '@/lib/utils/price';
+import { useToastStore } from '@/lib/zustand/store/toast-store';
+import { useUserStore } from '@/lib/zustand/store/user-store';
 
-const ProductInfoCard = ({ auctionId }: { auctionId: string }) => {
-  const [isDone, setIsDone] = useState(false);
+import { AuctionStatus } from '@/types/auction';
+
+interface ProductInfoCardProps {
+  auctionId: string;
+  status: AuctionStatus;
+}
+
+const ProductInfoCard = ({ auctionId, status }: ProductInfoCardProps) => {
+  const [isDone, setIsDone] = useState(status !== 'ACTIVE');
+  const { showToast } = useToastStore();
+  const currentUserId = useUserStore((state) => state.user?.id);
 
   const {
     data: auctionDetailData,
@@ -25,28 +38,36 @@ const ProductInfoCard = ({ auctionId }: { auctionId: string }) => {
   const auction = auctionDetailData?.data;
   const { data: initialBidsData } = useBidsByAuction(auctionId, 1);
 
+  const firstBid = initialBidsData?.data?.[0]?.price;
   const fallbackPrice =
-    Number(initialBidsData?.data?.[0]?.price) ?? Number(auction?.auctionPrice?.currentPrice ?? 0);
+    firstBid != null
+      ? Number(firstBid)
+      : Number(auction?.auctionPrice?.currentPrice ?? auction?.auctionPrice?.startPrice ?? 0);
+
   const { currentPrice, refetchCurrentPrice } = useCurrentPrice(auctionId, fallbackPrice);
   const price = formatCurrencyWithUnit(currentPrice);
 
-  const handleClick = () => setIsDone((prev) => !prev);
   const color = isDone ? 'disabled' : 'primary';
 
+  const handleComplete = () => {
+    setIsDone(true);
+    updateAuctionStatus(auctionId, 'COMPLETED');
+  };
+
   if (isLoading) {
-    return (
-      <div className={productCardStyle().wrapper()}>
-        <div className={productCardStyle().loading()}>경매 정보를 불러오는 중...</div>
-      </div>
-    );
+    return <ProductCardSkeleton />;
   }
 
   if (error || !auctionDetailData?.data) {
+    showToast({
+      status: 'error',
+      title: '불러오기 실패',
+      subtext: '상품 불러오기가 실패했습니다. 다시 시도 버튼을 클릭해주세요.',
+      autoClose: true,
+    });
+
     return (
       <div className={productCardStyle().wrapper()}>
-        <div className={productCardStyle().error()}>
-          경매 정보를 불러오는 중 오류가 발생했습니다.
-        </div>
         <Button
           variant="outline"
           color={color}
@@ -62,7 +83,7 @@ const ProductInfoCard = ({ auctionId }: { auctionId: string }) => {
 
   return (
     <div className={productCardStyle().wrapper()}>
-      <div className="flex h-full w-full items-center gap-2">
+      <div className={productCardStyle().content()}>
         {auction && auction.thumbnailUrl && auction.thumbnailUrl.length > 0 && (
           <Thumbnail
             url={auction.thumbnailUrl}
@@ -70,14 +91,14 @@ const ProductInfoCard = ({ auctionId }: { auctionId: string }) => {
             className="h-12 w-12 shrink-0"
           />
         )}
-        <p className="flex min-w-0 flex-1 flex-col">
+        <p className={productCardStyle().infoBox()}>
           <span className="overflow-hidden truncate whitespace-nowrap text-base font-medium">
             {auction?.title}
           </span>
           <span className="text-sm font-medium text-neutral-600">현재가 {price}</span>
         </p>
       </div>
-      <div className="flex items-center justify-end gap-2">
+      <div className={productCardStyle().buttonBox()}>
         <Button
           variant="outline"
           color={color}
@@ -87,16 +108,18 @@ const ProductInfoCard = ({ auctionId }: { auctionId: string }) => {
         >
           새로고침
         </Button>
-        <Button
-          variant="outline"
-          color={color}
-          size="min"
-          onClick={handleClick}
-          className="w-1/5"
-          disabled={isDone}
-        >
-          거래종료
-        </Button>
+        {auction?.sellerId == currentUserId && (
+          <Button
+            variant="outline"
+            color={color}
+            size="min"
+            onClick={handleComplete}
+            className="w-1/5"
+            disabled={isDone}
+          >
+            거래종료
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/chat/product-info-card.tsx
+++ b/apps/web/src/components/chat/product-info-card.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-import ProductCardSkeleton from '@/components/chat/product-card-skeleton';
+import { ProductCardSkeleton } from '@/components/chat';
 import productCardStyle from '@/components/chat/style';
 import { Button } from '@/components/ui';
 import Thumbnail from '@/components/ui/thumbnail';

--- a/apps/web/src/components/chat/style.ts
+++ b/apps/web/src/components/chat/style.ts
@@ -3,8 +3,20 @@ import { tv } from 'tailwind-variants';
 const productCardStyle = tv({
   slots: {
     wrapper: 'border-y-1 flex h-auto w-full flex-col justify-between border-neutral-100 p-3',
-    loading: 'text-lg text-neutral-600',
-    error: 'text-danger-600 text-lg',
+    content: 'flex h-full w-full items-center gap-2',
+    infoBox: 'flex min-w-0 flex-1 flex-col',
+    buttonBox: 'flex items-center justify-end gap-2',
+  },
+  variants: {
+    loading: {
+      true: {
+        wrapper: 'animate-pulse',
+        content: 'animate-pulse',
+      },
+    },
+  },
+  defaultVariants: {
+    loading: false,
   },
 });
 

--- a/apps/web/src/hooks/auction/useCurrentPrice.ts
+++ b/apps/web/src/hooks/auction/useCurrentPrice.ts
@@ -27,7 +27,10 @@ export const useCurrentPrice = (auctionId: string, fallbackPrice: number) => {
 
   const currentPrice = useMemo(() => {
     const bids = bidsData?.data ?? [];
-    return bids.length === 0 ? fallbackPrice : Math.max(...bids.map((b) => Number(b.price)));
+    if (bids.length === 0) {
+      return fallbackPrice;
+    }
+    return Math.max(...bids.map((b) => Number(b.price)));
   }, [bidsData, fallbackPrice]);
 
   return { currentPrice, refetchCurrentPrice: refetch, isFetching };

--- a/apps/web/src/lib/actions/auction.ts
+++ b/apps/web/src/lib/actions/auction.ts
@@ -5,7 +5,7 @@ import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase/server';
 import { convertHoursToTimestamp } from '@/lib/utils/date';
 
-import { AuctionFormData, AuctionPriceUpdate } from '@/types/auction';
+import { AuctionFormData, AuctionPriceUpdate, AuctionStatus } from '@/types/auction';
 
 // Create
 export const createAuction = async (data: AuctionFormData, userId: string) => {
@@ -270,4 +270,32 @@ export const addAuctionImages = async (itemId: string, imageUrls: string[]) => {
   });
 
   if (error) throw new Error(`이미지 저장 실패: ${error.message}`);
+};
+
+export const getAuctionStatus = async (itemId: string) => {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('auction_items')
+    .select('status')
+    .eq('id', itemId)
+    .single();
+
+  if (error) throw new Error(`경매 상태 조회 실패: ${error.message}`);
+
+  return data.status;
+};
+
+export const updateAuctionStatus = async (itemId: string, status: AuctionStatus) => {
+  const supabase = await createClient();
+
+  const { error } = await supabase
+    .from('auction_items')
+    .update({ status })
+    .eq('id', itemId)
+    .select('status')
+    .single();
+
+  if (error) {
+    throw new Error(`경매 상태 업데이트 실패: ${error.message}`);
+  }
 };

--- a/apps/web/src/lib/types/auction.ts
+++ b/apps/web/src/lib/types/auction.ts
@@ -30,14 +30,6 @@ export interface AuctionFormData {
   is_extended_auction?: boolean;
 }
 
-export interface Auction extends AuctionFormData {
-  id: string;
-  seller_id: string;
-  status: AuctionStatus;
-  thumbnail_url: string;
-  created_at: string;
-}
-
 export interface AuctionPriceUpdate {
   instant_price?: number | null;
   min_bid_unit: number;
@@ -48,16 +40,7 @@ export interface AuctionPriceUpdate {
   current_price?: number;
 }
 
-export type AuctionStatus =
-  | 'pending'
-  | 'ongoing'
-  | 'ended'
-  | 'sold'
-  | 'canceled'
-  | 'waiting'
-  | 'live'
-  | 'paused'
-  | 'closed';
+export type AuctionStatus = 'ACTIVE' | 'COMPLETED';
 
 //경매 게시글 등록 폼 타입들
 //이미지 등록 타입


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
closes #390 

- product-info-card skeleton 추가
- product-info-card 로드 에러 발생 시 처리
- product 거래 상태 변경 시 처리
    - 성공 시 안내 문구 및 버튼 disabled
    - 거래 종료 버튼 클릭 시 api 요청

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

채팅 UI에서 경매 종료 흐름을 구현합니다. 이를 위해 경매 상태를 가져와 전달하고, 로딩 및 에러 컴포넌트를 표시하며, 판매자가 비활성화 상태를 인지하는 버튼을 통해 경매를 완료하고, 토스트를 통해 사용자에게 알림을 제공합니다.

새로운 기능:
- 판매자를 위한 "거래종료" 버튼을 통해 상태를 업데이트하고 확인 토스트를 표시하는 경매 완료 흐름을 채팅 상품 카드에 도입합니다.
- 채팅 상품 정보 카드용 전용 로딩 스켈레톤 및 에러 상태 컴포넌트를 추가합니다.
- 채팅 페이지에서 초기 경매 상태를 가져와 상품 정보 카드에 전달합니다.

개선 사항:
- `product-info-card`를 리팩터링하여 토스트 알림 및 사용자 정보를 위해 zustand 스토어를 사용하고 스타일링 변형을 통합합니다.
- 빈 입찰 시나리오를 명시적으로 처리하도록 `useCurrentPrice` 훅 로직을 단순화합니다.

작업:
- `getAuctionStatus` 및 `updateAuctionStatus` 액션을 추가하고 `AuctionStatus` 타입을 정의합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement auction end flow in the chat UI by fetching and passing auction status, showing loading and error components, enabling sellers to complete auctions via a disabled-aware button, and notifying users through toasts

New Features:
- Introduce auction completion flow in chat product card with a “거래종료” button for sellers that updates status and shows confirmation toast
- Add dedicated loading skeleton and error state components for the chat product info card
- Fetch initial auction status on the chat page and pass it to the product info card

Enhancements:
- Refactor product-info-card to use zustand stores for toast notifications and user info and consolidate styling variants
- Simplify useCurrentPrice hook logic to explicitly handle empty bid scenarios

Chores:
- Add getAuctionStatus and updateAuctionStatus actions and define AuctionStatus type

</details>