### PR TITLE
[feat] 경매상세페이지 헤더 섀도우 추가

### DIFF
--- a/apps/web/src/components/common/button/more.tsx
+++ b/apps/web/src/components/common/button/more.tsx
@@ -27,7 +27,7 @@ const ButtonMore = ({ items }: ButtonMoreProps) => {
           <EllipsisVertical />
         </button>
       </PopoverTrigger>
-      <PopoverContent className="w-25 py-2">
+      <PopoverContent className="w-25 bg-white py-2 shadow-none">
         <ul className="space-y-2">
           {items.map((item) => (
             <li

--- a/apps/web/src/components/layout/header/auction.tsx
+++ b/apps/web/src/components/layout/header/auction.tsx
@@ -116,6 +116,9 @@ const AuctionHeader = () => {
     <>
       <HeaderWrapper
         className={`${id && !pathname.includes('edit') ? 'absolute z-10 text-white' : 'bg-white'}`}
+        style={{
+          boxShadow: `${id && !pathname.includes('edit') ? 'inset 0 60px 25px -17px rgba(0, 0, 0, 0.1)' : 'none'}`,
+        }}
       >
         <button type="button" onClick={handleBackClick}>
           <ChevronLeftIcon />

--- a/apps/web/src/components/layout/header/auction.tsx
+++ b/apps/web/src/components/layout/header/auction.tsx
@@ -117,7 +117,7 @@ const AuctionHeader = () => {
       <HeaderWrapper
         className={`${id && !pathname.includes('edit') ? 'absolute z-10 text-white' : 'bg-white'}`}
         style={{
-          boxShadow: `${id && !pathname.includes('edit') ? 'inset 0 60px 25px -17px rgba(0, 0, 0, 0.1)' : 'none'}`,
+          boxShadow: id && !pathname.includes('edit') ? 'var(--shadow-md)' : 'none',
         }}
       >
         <button type="button" onClick={handleBackClick}>

--- a/apps/web/src/components/layout/header/wrapper.tsx
+++ b/apps/web/src/components/layout/header/wrapper.tsx
@@ -1,12 +1,15 @@
+import { cn } from '@/lib/cn';
+
 interface HeaderWrapperProps {
   children: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
 }
+
 const HeaderWrapper = ({ children, className, style }: HeaderWrapperProps) => {
   return (
     <header
-      className={`flex h-16 w-full items-center justify-between px-4 ${className}`}
+      className={cn('flex h-16 w-full items-center justify-between px-4', className)}
       style={style}
     >
       {children}

--- a/apps/web/src/components/layout/header/wrapper.tsx
+++ b/apps/web/src/components/layout/header/wrapper.tsx
@@ -1,12 +1,14 @@
-const HeaderWrapper = ({
-  children,
-  className,
-}: {
+interface HeaderWrapperProps {
   children: React.ReactNode;
   className?: string;
-}) => {
+  style?: React.CSSProperties;
+}
+const HeaderWrapper = ({ children, className, style }: HeaderWrapperProps) => {
   return (
-    <header className={`flex h-16 w-full items-center justify-between px-4 ${className}`}>
+    <header
+      className={`flex h-16 w-full items-center justify-between px-4 ${className}`}
+      style={style}
+    >
       {children}
     </header>
   );

--- a/packages/tailwind-config/shared-styles.css
+++ b/packages/tailwind-config/shared-styles.css
@@ -53,7 +53,6 @@ h6 {
   height: 0;
 }
 
-
 @theme {
   /* Primary Colors */
   --color-primary-50: #edf0ff;
@@ -65,7 +64,7 @@ h6 {
   --color-primary-600: #4238f1;
   --color-primary-700: #372ecf;
   --color-primary-800: #2e29a0;
-  --color-primary-950: #16214A;
+  --color-primary-950: #16214a;
 
   /* Success Colors */
   --color-success-50: #f0fdfa;
@@ -157,8 +156,9 @@ h6 {
     0px -83px 23px 0px rgba(203, 195, 195, 0), 0px -53px 21px 0px rgba(203, 195, 195, 0.01),
     0px -30px 18px 0px rgba(203, 195, 195, 0.05), 0px -13px 13px 0px rgba(203, 195, 195, 0.09),
     0px -3px 7px 0px rgba(203, 195, 195, 0.1);
-}
 
+  --shadow-md: inset 0 60px 25px -17px rgba(0, 0, 0, 0.1);
+}
 .korean-calendar th:first-child {
   color: rgb(239 68 68);
   /* red-500 */


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
closes #402 
## 📋 작업 내용

<img width="350" alt="스크린샷 2025-07-30 오전 1 48 46" src="https://github.com/user-attachments/assets/f130898d-7941-4b3b-96cd-125f89f853a3" />


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Summary by Sourcery
Sourcery 요약

경매 상세 페이지 헤더에 조건부 인셋 섀도우를 도입하기 위해 HeaderWrapper 컴포넌트를 확장하여 인라인 스타일을 적용합니다.

New Features:
- (수정 모드가 아닌) 보기 모드일 때 경매 상세 헤더에 인셋 박스 섀도우를 적용합니다.

Enhancements:
- 인라인 CSS를 위한 `style` prop을 허용하도록 HeaderWrapper를 확장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a conditional inset shadow on the auction detail page header by extending the HeaderWrapper component to accept inline styles

New Features:
- Apply an inset box-shadow to the auction detail header when viewing (non-edit)

Enhancements:
- Extend HeaderWrapper to accept a style prop for inline CSS

</details>