### PR TITLE
[Feat] 홈 셀렉 스켈레톤

### DIFF
--- a/apps/web/src/components/layout/home-filter-select.tsx
+++ b/apps/web/src/components/layout/home-filter-select.tsx
@@ -78,7 +78,7 @@ const HomeFilterSelect = () => {
   if (isLoading) {
     return (
       <div className={cn(homeFilterWrapper, 'gap-2')}>
-        <div className="h-9 w-14 rounded-sm bg-neutral-200"></div>
+        <div className="h-9 w-14 animate-pulse rounded-sm bg-neutral-200"></div>
         <ChevronDown size={24} className="text-neutral-400" />
       </div>
     );

--- a/apps/web/src/components/layout/home-filter-select.tsx
+++ b/apps/web/src/components/layout/home-filter-select.tsx
@@ -78,7 +78,7 @@ const HomeFilterSelect = () => {
   if (isLoading) {
     return (
       <div className={cn(homeFilterWrapper, 'gap-2')}>
-        <div>loading...</div>
+        <div className="h-9 w-14 rounded-sm bg-neutral-200"></div>
         <ChevronDown size={24} className="text-neutral-400" />
       </div>
     );

--- a/apps/web/src/components/personal-info/purchases/purchases-list.tsx
+++ b/apps/web/src/components/personal-info/purchases/purchases-list.tsx
@@ -58,7 +58,7 @@ const PurchasesList = ({ userId }: PurchasesListProps) => {
       <div>
         <FilterTab filterKey="trade" items={AUCTION_TABS_BASIC} />
         <div className="flex flex-col gap-3">
-          {Array.from({ length: 8 }).map((_, index) => (
+          {Array.from({ length: 6 }).map((_, index) => (
             <AuctionCardSkeleton key={index} />
           ))}
         </div>

--- a/apps/web/src/components/personal-info/purchases/purchases-list.tsx
+++ b/apps/web/src/components/personal-info/purchases/purchases-list.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 
+import AuctionCardSkeleton from '@/components/auction/auction-card-skeleton';
 import { FilterTab, AuctionCard } from '@/components/common';
 
 import { useMyPurchases } from '@/hooks/queries/profile';
@@ -11,7 +12,6 @@ import { convertToAuctionItemProps } from '@/lib/utils/auction';
 import { useFilterStore } from '@/lib/zustand/store';
 
 import { AuctionStatus } from '@/types/filter';
-
 // 기본 탭 ID 타입 정의
 type BasicTabId = 'all' | 'ongoing' | 'completed';
 
@@ -57,8 +57,10 @@ const PurchasesList = ({ userId }: PurchasesListProps) => {
     return (
       <div>
         <FilterTab filterKey="trade" items={AUCTION_TABS_BASIC} />
-        <div className="flex items-center justify-center py-16">
-          <div className="text-lg text-neutral-600">구매 내역을 불러오는 중...</div>
+        <div className="flex flex-col gap-3">
+          {Array.from({ length: 8 }).map((_, index) => (
+            <AuctionCardSkeleton key={index} />
+          ))}
         </div>
       </div>
     );

--- a/apps/web/src/components/personal-info/sales/sales-list.tsx
+++ b/apps/web/src/components/personal-info/sales/sales-list.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 
+import AuctionCardSkeleton from '@/components/auction/auction-card-skeleton';
 import { FilterTab, AuctionCard } from '@/components/common';
 
 import { useMySales } from '@/hooks/queries/profile';
@@ -59,8 +60,10 @@ const SalesList = ({ userId }: SalesListProps) => {
     return (
       <div>
         <FilterTab filterKey="trade" items={AUCTION_TABS_BASIC} />
-        <div className="flex items-center justify-center py-16">
-          <div className="text-lg text-neutral-600">판매 내역을 불러오는 중...</div>
+        <div className="flex flex-col gap-3">
+          {Array.from({ length: 8 }).map((_, index) => (
+            <AuctionCardSkeleton key={index} />
+          ))}
         </div>
       </div>
     );

--- a/apps/web/src/components/personal-info/sales/sales-list.tsx
+++ b/apps/web/src/components/personal-info/sales/sales-list.tsx
@@ -61,7 +61,7 @@ const SalesList = ({ userId }: SalesListProps) => {
       <div>
         <FilterTab filterKey="trade" items={AUCTION_TABS_BASIC} />
         <div className="flex flex-col gap-3">
-          {Array.from({ length: 8 }).map((_, index) => (
+          {Array.from({ length: 6 }).map((_, index) => (
             <AuctionCardSkeleton key={index} />
           ))}
         </div>

--- a/apps/web/src/components/personal-info/wish/wishlist.tsx
+++ b/apps/web/src/components/personal-info/wish/wishlist.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 
+import AuctionCardSkeleton from '@/components/auction/auction-card-skeleton';
 import { FilterTab, AuctionCard } from '@/components/common';
 
 import { useMyWishlist } from '@/hooks/queries/profile';
@@ -59,8 +60,10 @@ const Wishlist = ({ userId }: WishlistProps) => {
     return (
       <div>
         <FilterTab filterKey="trade" items={AUCTION_TABS_BASIC} />
-        <div className="flex items-center justify-center py-16">
-          <div className="text-lg text-neutral-600">찜한 상품을 불러오는 중...</div>
+        <div className="flex flex-col gap-3">
+          {Array.from({ length: 8 }).map((_, index) => (
+            <AuctionCardSkeleton key={index} />
+          ))}
         </div>
       </div>
     );

--- a/apps/web/src/components/personal-info/wish/wishlist.tsx
+++ b/apps/web/src/components/personal-info/wish/wishlist.tsx
@@ -61,7 +61,7 @@ const Wishlist = ({ userId }: WishlistProps) => {
       <div>
         <FilterTab filterKey="trade" items={AUCTION_TABS_BASIC} />
         <div className="flex flex-col gap-3">
-          {Array.from({ length: 8 }).map((_, index) => (
+          {Array.from({ length: 6 }).map((_, index) => (
             <AuctionCardSkeleton key={index} />
           ))}
         </div>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
closes #396 
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

홈 셀렉박스 스켈레톤
프로필 하위 페이지 경매 조회 스켈레톤 적용

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 제공 요약

홈 필터 선택 및 사용자 경매 목록에 스켈레톤 로딩 컴포넌트 추가

개선 사항:
- 구매, 판매, 위시리스트 목록에서 로딩 텍스트를 반복되는 `AuctionCardSkeleton` 컴포넌트로 대체
- 홈 필터 선택에서 로딩 인디케이터를 깜빡이는 스켈레톤 플레이스홀더로 대체

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add skeleton loading components to the home filter select and user auction lists

Enhancements:
- Replace loading text with repeated AuctionCardSkeleton components in purchases, sales, and wishlist lists
- Replace loading indicator in home filter select with a pulsating skeleton placeholder

</details>