### PR TITLE
[feat] 채팅 추가 입력 부분 toast 연결

### DIFF
--- a/apps/web/src/components/chat/input/input-bar.tsx
+++ b/apps/web/src/components/chat/input/input-bar.tsx
@@ -31,7 +31,7 @@ const InputBar = ({ roomId }: { roomId: string }) => {
         <ChatInputForm roomId={roomId} />
       </div>
       {isClicked && (
-        <div className="flex justify-start gap-10 px-8 pb-[15%] pt-2">
+        <div className="gap20 flex justify-around px-4 pb-[15%] pt-2">
           <InputImage />
           <InputCamera />
           <ButtonAddress />

--- a/apps/web/src/components/chat/input/input-bar.tsx
+++ b/apps/web/src/components/chat/input/input-bar.tsx
@@ -31,7 +31,7 @@ const InputBar = ({ roomId }: { roomId: string }) => {
         <ChatInputForm roomId={roomId} />
       </div>
       {isClicked && (
-        <div className="flex justify-around gap-2 px-4 pb-[15%] pt-2">
+        <div className="flex justify-start gap-10 px-8 pb-[15%] pt-2">
           <InputImage />
           <InputCamera />
           <ButtonAddress />

--- a/apps/web/src/components/chat/input/input-bar.tsx
+++ b/apps/web/src/components/chat/input/input-bar.tsx
@@ -31,7 +31,7 @@ const InputBar = ({ roomId }: { roomId: string }) => {
         <ChatInputForm roomId={roomId} />
       </div>
       {isClicked && (
-        <div className="gap20 flex justify-around px-4 pb-[15%] pt-2">
+        <div className="flex justify-around gap-2 px-4 pb-[15%] pt-2">
           <InputImage />
           <InputCamera />
           <ButtonAddress />

--- a/apps/web/src/components/chat/input/input-camera.tsx
+++ b/apps/web/src/components/chat/input/input-camera.tsx
@@ -20,12 +20,10 @@ const InputCamera = () => {
 
   return (
     <div className={serviceStyle().wrapper()}>
-      <label className={serviceStyle().label()}>
-        <button type="button" className={serviceStyle().label()} onClick={handleClick}>
-          {/*<input type="file" className="hidden" accept="image/*" capture="environment" />*/}
-          <Camera size={28} />
-        </button>
-      </label>
+      <button type="button" className={serviceStyle().label()} onClick={handleClick}>
+        {/*<input type="file" className="hidden" accept="image/*" capture="environment" />*/}
+        <Camera size={28} />
+      </button>
       <p className={serviceStyle().title()}>카메라</p>
     </div>
   );

--- a/apps/web/src/components/chat/input/input-camera.tsx
+++ b/apps/web/src/components/chat/input/input-camera.tsx
@@ -1,13 +1,30 @@
+'use client';
+
 import { Camera } from 'lucide-react';
 
 import serviceStyle from '@/components/chat/input/style';
 
+import { useToastStore } from '@/lib/zustand/store';
+
 const InputCamera = () => {
+  const { showToast } = useToastStore();
+
+  const handleClick = () => {
+    showToast({
+      status: 'notice',
+      title: '준비중인 기능',
+      subtext: '카메라 촬영 및 전송 기능은 현재 준비중입니다.',
+      autoClose: true,
+    });
+  };
+
   return (
     <div className={serviceStyle().wrapper()}>
       <label className={serviceStyle().label()}>
-        <input type="file" className="hidden" accept="image/*" capture="environment" />
-        <Camera size={28} />
+        <button type="button" className={serviceStyle().label()} onClick={handleClick}>
+          {/*<input type="file" className="hidden" accept="image/*" capture="environment" />*/}
+          <Camera size={28} />
+        </button>
       </label>
       <p className={serviceStyle().title()}>카메라</p>
     </div>

--- a/apps/web/src/components/chat/input/input-image.tsx
+++ b/apps/web/src/components/chat/input/input-image.tsx
@@ -1,14 +1,29 @@
+'use client';
+
 import { Images } from 'lucide-react';
 
 import serviceStyle from '@/components/chat/input/style';
 
+import { useToastStore } from '@/lib/zustand/store';
+
 const InputImage = () => {
+  const { showToast } = useToastStore();
+
+  const handleClick = () => {
+    showToast({
+      status: 'notice',
+      title: '준비중인 기능',
+      subtext: '이미지 전송 기능은 현재 준비중입니다.',
+      autoClose: true,
+    });
+  };
+
   return (
     <div className={serviceStyle().wrapper()}>
-      <label className={serviceStyle().label()}>
-        <input type="file" className="hidden" accept="image/*,video/*" />
+      <button type="button" className={serviceStyle().label()} onClick={handleClick}>
+        {/*<input type="file" className="hidden" accept="image/*,video/*" capture="environment" />*/}
         <Images size={28} />
-      </label>
+      </button>
       <p className={serviceStyle().title()}>사진/동영상</p>
     </div>
   );

--- a/apps/web/src/components/common/toast.tsx
+++ b/apps/web/src/components/common/toast.tsx
@@ -85,7 +85,7 @@ const Toast = () => {
       notice: {
         container: 'bg-neutral-900 shadow-[0px_6px_12px_-3px_rgba(82,82,82,0.12)]',
         title: 'text-neutral-200',
-        subtext: '',
+        subtext: 'text-neutral-50',
         closeBtn: '',
       },
     };

--- a/apps/web/src/components/personal-info/account/drawer-content.tsx
+++ b/apps/web/src/components/personal-info/account/drawer-content.tsx
@@ -3,43 +3,30 @@
 import { useState } from 'react';
 
 import { AccountItem, ButtonManage, ButtonSelect, DrawerHeader } from '@/components/personal-info';
+import { AccountListItem } from '@/components/personal-info/account/item';
 import { Button, DrawerContent } from '@/components/ui';
+
+import { useToastStore } from '@/lib/zustand/store';
 
 import { ACCOUNT_DRAWER_HEADER } from '@/constants/personal-info';
 
 const AccountDrawerContent = () => {
-  const dummyAccount = [
-    {
-      id: '1',
-      name: '김커널',
-      bank: '패스트뱅크',
-      account: '010-1234-5678',
-      isPrimary: true,
-    },
-    {
-      id: '2',
-      name: '김커널',
-      bank: '패스트뱅크',
-      account: '010-1234-5678',
-      isPrimary: false,
-    },
-    {
-      id: '3',
-      name: '김커널',
-      bank: '패스트뱅크',
-      account: '010-1234-5678',
-      isPrimary: false,
-    },
-  ];
+  const [accountList, setAccountList] = useState<AccountListItem[]>([]);
+  const { showToast } = useToastStore();
 
+  const handleClick = () => {
+    showToast({
+      status: 'notice',
+      title: '준비중인 기능',
+      subtext: '주소 공유 기능은 현재 준비중입니다.',
+      autoClose: true,
+    });
+  };
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
 
   const handleSelect = (id: string) => {
     setSelectedAccountId(id === selectedAccountId ? null : id);
   };
-
-  // TODO: 해당하는 id 에 대하여 메세지 컴포넌트로 공유하는 onClick 함수 넣어주기
-  // TODO: manage-button 에 @modal 경로 넣어주기
 
   return (
     <DrawerContent className="flex flex-col gap-2 p-4">
@@ -48,7 +35,10 @@ const AccountDrawerContent = () => {
         description={ACCOUNT_DRAWER_HEADER.description}
       />
       <ul className="flex flex-col gap-2">
-        {dummyAccount.map((account) => (
+        {accountList.length === 0 && (
+          <p className="py-10 text-center text-neutral-600">등록된 계좌가 없습니다.</p>
+        )}
+        {accountList.map((account) => (
           <li key={account.id}>
             <AccountItem
               color={selectedAccountId === account.id ? 'selected' : 'default'}
@@ -63,7 +53,7 @@ const AccountDrawerContent = () => {
         ))}
       </ul>
       <ButtonManage title="계좌 관리" url="/account" />
-      <Button variant="solid" size="lg">
+      <Button variant="solid" size="lg" onClick={handleClick}>
         공유하기
       </Button>
     </DrawerContent>

--- a/apps/web/src/components/personal-info/account/item.tsx
+++ b/apps/web/src/components/personal-info/account/item.tsx
@@ -15,10 +15,10 @@ const style = tv({
 interface AccountProps {
   color?: 'default' | 'selected';
   children: React.ReactNode;
-  account: AccountItem;
+  account: AccountListItem;
 }
 
-export interface AccountItem {
+export interface AccountListItem {
   id: string;
   name: string;
   bank: string;

--- a/apps/web/src/components/personal-info/address/address-item.tsx
+++ b/apps/web/src/components/personal-info/address/address-item.tsx
@@ -2,6 +2,8 @@ import { tv } from 'tailwind-variants';
 
 import { BadgePrimary } from '@/components/personal-info';
 
+import { AddressListItem } from '@/types/address';
+
 const style = tv({
   base: 'flex items-center justify-between rounded-xl p-3',
   variants: {
@@ -18,15 +20,7 @@ const style = tv({
 interface AddressProps {
   color?: 'default' | 'selected';
   children: React.ReactNode;
-  address: AddressItem;
-}
-
-export interface AddressItem {
-  id: string;
-  name: string;
-  address: string;
-  phone: string;
-  isPrimary: boolean;
+  address: AddressListItem;
 }
 
 const Address = ({ color, children, address }: AddressProps) => {
@@ -34,7 +28,7 @@ const Address = ({ color, children, address }: AddressProps) => {
     <div className={style({ color })}>
       <div className="flex flex-col">
         <div className="flex items-center gap-2">
-          <p className="text-lg font-medium text-neutral-900">{address.name}</p>
+          <p className="text-lg font-medium text-neutral-900">{address.userName}</p>
           {address.isPrimary && <BadgePrimary />}
         </div>
         <div className="text-sm font-medium">

--- a/apps/web/src/components/personal-info/address/drawer-content.tsx
+++ b/apps/web/src/components/personal-info/address/drawer-content.tsx
@@ -5,41 +5,30 @@ import { useState } from 'react';
 import { AddressItem, ButtonManage, ButtonSelect, DrawerHeader } from '@/components/personal-info';
 import { Button, DrawerContent } from '@/components/ui';
 
+import { useToastStore } from '@/lib/zustand/store';
+
+import { AddressListItem } from '@/types/address';
+
 import { ADDRESS_DRAWER_HEADER } from '@/constants/personal-info';
 
 const AddressDrawerContent = () => {
-  const dummyAddress = [
-    {
-      id: '1',
-      name: '김커널',
-      address: '서울 강남구 강남대로 364',
-      phone: '010-1234-5678',
-      isPrimary: true,
-    },
-    {
-      id: '2',
-      name: '김커널',
-      address: '서울 강남구 강남대로 364',
-      phone: '010-1234-5678',
-      isPrimary: false,
-    },
-    {
-      id: '3',
-      name: '김커널',
-      address: '서울 강남구 강남대로 364',
-      phone: '010-1234-5678',
-      isPrimary: false,
-    },
-  ];
+  const [addressList, setAddressList] = useState<AddressListItem[]>([]);
+  const { showToast } = useToastStore();
+
+  const handleClick = () => {
+    showToast({
+      status: 'notice',
+      title: '준비중인 기능',
+      subtext: '주소 공유 기능은 현재 준비중입니다.',
+      autoClose: true,
+    });
+  };
 
   const [selectedAddressId, setSelectedAddressId] = useState<string | null>(null);
 
   const handleSelect = (id: string) => {
     setSelectedAddressId(id === selectedAddressId ? null : id);
   };
-
-  // TODO: 해당하는 id 에 대하여 메세지 컴포넌트로 공유하는 onClick 함수 넣어주기
-  // TODO: manage-button 에 @modal 경로 넣어주기
 
   return (
     <DrawerContent className="flex flex-col gap-2 p-4">
@@ -48,7 +37,10 @@ const AddressDrawerContent = () => {
         description={ADDRESS_DRAWER_HEADER.description}
       />
       <ul className="flex flex-col gap-2">
-        {dummyAddress.map((address) => (
+        {addressList.length === 0 && (
+          <p className="py-10 text-center text-neutral-600">등록된 주소가 없습니다.</p>
+        )}
+        {addressList.map((address) => (
           <li key={address.id}>
             <AddressItem
               color={selectedAddressId === address.id ? 'selected' : 'default'}
@@ -63,7 +55,7 @@ const AddressDrawerContent = () => {
         ))}
       </ul>
       <ButtonManage url="/address" title="주소 관리" />
-      <Button variant="solid" size="lg">
+      <Button variant="solid" size="lg" onClick={handleClick}>
         공유하기
       </Button>
     </DrawerContent>

--- a/apps/web/src/components/personal-info/address/list.tsx
+++ b/apps/web/src/components/personal-info/address/list.tsx
@@ -1,40 +1,23 @@
+'use client';
+
+import { useState } from 'react';
+
 import { AddressItem, ButtonBox, ButtonCreate } from '@/components/personal-info';
 
-const AddressList = () => {
-  const dummyAddress = [
-    {
-      id: '1',
-      name: '김커널',
-      address: '서울 강남구 강남대로 364',
-      phone: '010-1234-5678',
-      isPrimary: true,
-    },
-    {
-      id: '2',
-      name: '김커널',
-      address: '서울 강남구 강남대로 364',
-      phone: '010-1234-5678',
-      isPrimary: false,
-    },
-    {
-      id: '3',
-      name: '김커널',
-      address: '서울 강남구 강남대로 364',
-      phone: '010-1234-5678',
-      isPrimary: false,
-    },
-  ];
+import { AddressListItem } from '@/types/address';
 
-  // TODO: 사용자 본인의 정보를 받아오는 api 요청 로직 추가
-  // TODO: ButtonBox 로 account.id 넘겨주기. 해당하는 account.id 에 대하여 수정 및 삭제 요청 로직 Button-Box 내에서 작성
-  // TODO: 주소를 더 이상 추가할 수 없는 경우
-  // const status = 'disabled';
+const AddressList = () => {
+  const [addressList, setAddressList] = useState<AddressListItem[]>([]);
+
   const status = 'default';
 
   return (
     <div className="flex h-full w-full flex-col justify-between px-4 pb-4">
       <ul className="flex flex-col gap-3">
-        {dummyAddress.map((address) => (
+        {addressList.length === 0 && (
+          <p className="py-10 text-center text-neutral-600">등록된 주소가 없습니다.</p>
+        )}
+        {addressList.map((address) => (
           <li key={address.id}>
             <AddressItem address={address}>
               <ButtonBox url={`/address/edit/${address.id}`} />

--- a/apps/web/src/lib/types/address.ts
+++ b/apps/web/src/lib/types/address.ts
@@ -20,6 +20,14 @@ export interface CreateAddressRequest {
   isPrimary?: boolean;
 }
 
+export interface AddressListItem {
+  id: string;
+  userName: string;
+  address: string;
+  phone: string;
+  isPrimary: boolean;
+}
+
 export interface AddressResponse {
   data: Address;
   error?: never;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안


## 📋 작업 내용
closes #414 

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

자리표시자 공유 및 업로드 기능을 전역 토스트 알림에 연결하고, 개인 정보 서랍의 하드코딩된 더미 데이터를 비어있는 상태 메시지를 포함하는 상태 기반 목록으로 대체하며, 목록 항목 유형을 통합하고, 채팅 입력 레이아웃 및 토스트 스타일을 개선합니다.

새로운 기능:
- 미구현된 계정/주소 공유 및 채팅 이미지/카메라 액션에 대한 토스트 알림 표시

개선 사항:
- 더미 계정 및 주소 배열을 상태 관리 목록으로 교체하고 비어 있을 때 대체 메시지 렌더링
- 통일된 AccountListItem 및 AddressListItem 유형을 항목 컴포넌트에서 추출하여 사용
- 일관된 레이아웃을 위해 채팅 입력 툴바 간격 및 패딩 조정
- 부텍스트 색상을 포함하도록 토스트 컴포넌트 스타일 업데이트

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Connect placeholder share and upload features to global toast notifications, remove hardcoded dummy data in personal-info drawers in favor of state-driven lists with empty-state messaging, unify list item types, and refine chat input layout and toast styling.

New Features:
- Show toast notifications for unimplemented account/address share and chat image/camera actions

Enhancements:
- Replace dummy account and address arrays with state-managed lists and render fallback messages when empty
- Extract and use unified AccountListItem and AddressListItem types in item components
- Adjust chat input toolbar spacing and padding for consistent layout
- Update toast component styling to include subtext color

</details>