### PR TITLE
[refactor] 프로필 페이지 리팩토링 #429

### DIFF
--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -4,7 +4,8 @@ import { redirect } from 'next/navigation';
 import { Pen } from 'lucide-react';
 
 import { MenuList, ProfileCard } from '@/components/common';
-import { LogoutButton } from '@/components/common/profile';
+import { ProfileShortcutMenu } from '@/components/common/profile';
+import ButtonSignOut from '@/components/user/button-sign-out';
 import { Button } from '@/components/ui';
 
 import { getMyProfile } from '@/lib/actions/profile';
@@ -20,7 +21,7 @@ const ProfilePage = async () => {
     <main className={`h-full overflow-auto bg-white`}>
       <div className="height-auto w-full bg-white">
         {/* Profile Card */}
-        <div className="border-b-4 border-neutral-200">
+        <div className="border-b-4 border-neutral-100 py-1">
           <ProfileCard
             nickname={profile.nickname || '사용자'}
             profileImg={profile.profileImg || '/avatar-male.svg'}
@@ -34,12 +35,13 @@ const ProfilePage = async () => {
           </ProfileCard>
         </div>
 
-        {/* Menu List */}
-        <div className="mt-8 px-6">
+        <ProfileShortcutMenu />
+
+        <div className="mt-6">
           <MenuList />
         </div>
 
-        <LogoutButton />
+        <ButtonSignOut />
       </div>
     </main>
   );

--- a/apps/web/src/components/common/profile/index.ts
+++ b/apps/web/src/components/common/profile/index.ts
@@ -2,3 +2,4 @@ export { default as ProfileCard } from './card';
 export { default as ProfileImage } from './image';
 export { default as LogoutButton } from './logout-button';
 export { default as MenuList } from './menu-list';
+export { default as ProfileShortcutMenu } from './shortcut-menu';

--- a/apps/web/src/components/common/profile/menu-list.tsx
+++ b/apps/web/src/components/common/profile/menu-list.tsx
@@ -6,56 +6,48 @@ interface MenuItem {
 }
 
 interface MenuSection {
-  id: string; // 고유 ID 추가!
+  id: string;
   title: string;
   items: MenuItem[];
 }
 
 const menuSections: MenuSection[] = [
   {
-    id: 'account', // 고유 ID
-    title: '계정 정보',
+    id: 'setting',
+    title: '설정',
     items: [
-      { title: '판매 내역', route: '/profile/sales' },
-      { title: '구매 내역', route: '/profile/purchases' },
-      { title: '관심 목록', route: '/profile/wishlist' },
-      { title: '위치 정보 설정', route: '/profile/location' },
-      { title: '계좌 관리', route: '/account' },
-      { title: '주소 관리', route: '/address' },
+      { title: '내 동네 설정', route: '/profile/location' },
+      { title: '거래 주소 관리', route: '/address' },
+      { title: '거래 계좌 관리', route: '/account' },
     ],
   },
   {
     id: 'support',
     title: '고객 지원',
     items: [
-      { title: '고객센터', route: '/profile/support' },
+      { title: 'Q&A', route: '/profile/support' },
       { title: '설정', route: '/profile/settings' },
     ],
   },
 ];
 
-const MenuList = () => {
-  return (
-    <nav aria-label="마이페이지 메뉴 목록">
-      {menuSections.map((section) => (
-        <section key={section.id} className="mb-14 w-full space-y-6">
-          <h2 className="mb-6 text-lg font-bold text-neutral-900">{section.title}</h2>
-          <ul className="space-y-6">
-            {section.items.map((item) => (
-              <li key={item.route}>
-                <Link
-                  href={item.route}
-                  className="block text-sm font-medium leading-[24px] text-neutral-900"
-                >
-                  {item.title}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </section>
-      ))}
-    </nav>
-  );
-};
+const MenuList = () => (
+  <nav aria-label="마이페이지 메뉴 목록" className="px-8">
+    {menuSections.map((section) => (
+      <section key={section.id} className="mt-8">
+        <h2 className="mb-4 text-sm font-bold text-neutral-400">{section.title}</h2>
+        <ul className="space-y-4">
+          {section.items.map((item) => (
+            <li key={item.route}>
+              <Link href={item.route} className="block py-1 text-sm font-medium text-neutral-900">
+                {item.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ))}
+  </nav>
+);
 
 export default MenuList;

--- a/apps/web/src/components/common/profile/shortcut-menu.tsx
+++ b/apps/web/src/components/common/profile/shortcut-menu.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+import { ShoppingCart, Tag, Heart } from 'lucide-react';
+
+const items = [
+  { icon: <ShoppingCart className="h-6 w-6" />, label: '구매목록', href: '/profile/purchases' },
+  { icon: <Tag className="h-6 w-6" />, label: '판매목록', href: '/profile/sales' },
+  { icon: <Heart className="h-6 w-6" />, label: '관심목록', href: '/profile/wishlist' },
+];
+
+const ProfileShortcutMenu = () => (
+  <div className="flex justify-around border-b-4 border-neutral-100 bg-white py-5">
+    {items.map(({ icon, label, href }) => (
+      <Link key={label} href={href} className="flex flex-col items-center gap-3">
+        {icon}
+        <span className="text-xs text-neutral-600">{label}</span>
+      </Link>
+    ))}
+  </div>
+);
+
+export default ProfileShortcutMenu;

--- a/apps/web/src/components/layout/header/profile.tsx
+++ b/apps/web/src/components/layout/header/profile.tsx
@@ -1,110 +1,54 @@
 'use client';
 
 import { usePathname, useRouter } from 'next/navigation';
-
-import { Settings, ChevronLeft } from 'lucide-react';
+import { ChevronLeft } from 'lucide-react';
 
 import { HeaderWrapper } from '@/components/layout/';
 import { Button } from '@/components/ui';
 
-// 헤더 정보 타입 정의
 interface HeaderInfo {
   title: string;
   showBackButton: boolean;
-  showSettingsButton: boolean;
 }
 
-// 경로별 헤더 설정
 const HEADER_CONFIG: Record<string, HeaderInfo> = {
-  '/profile': {
-    title: '나의 프로필',
-    showBackButton: false,
-    showSettingsButton: true,
-  },
-  '/profile/sales': {
-    title: '판매내역',
-    showBackButton: true,
-    showSettingsButton: false,
-  },
-  '/profile/purchases': {
-    title: '구매 내역',
-    showBackButton: true,
-    showSettingsButton: false,
-  },
-  '/profile/wishlist': {
-    title: '관심 목록',
-    showBackButton: true,
-    showSettingsButton: false,
-  },
-  '/profile/location': {
-    title: '위치 정보 설정',
-    showBackButton: true,
-    showSettingsButton: false,
-  },
-  '/profile/support': {
-    title: '고객 센터',
-    showBackButton: true,
-    showSettingsButton: false,
-  },
-  '/profile/settings': {
-    title: '설 정',
-    showBackButton: true,
-    showSettingsButton: false,
-  },
+  '/profile': { title: '나의 프로필', showBackButton: false },
+  '/profile/sales': { title: '판매목록', showBackButton: true },
+  '/profile/purchases': { title: '구매목록', showBackButton: true },
+  '/profile/wishlist': { title: '관심목록', showBackButton: true },
+  '/profile/location': { title: '내 동네 설정', showBackButton: true },
+  '/profile/support': { title: 'Q&A', showBackButton: true },
+  '/profile/settings': { title: '설정', showBackButton: true },
 };
 
 const ProfileHeader = () => {
   const pathname = usePathname();
   const router = useRouter();
 
-  // 현재 경로의 헤더 정보 가져오기
-  const headerInfo = HEADER_CONFIG[pathname] || {
+  const { title, showBackButton } = HEADER_CONFIG[pathname] || {
     title: '프로필',
     showBackButton: true,
-    showSettingsButton: false,
-  };
-
-  const { title, showBackButton, showSettingsButton } = headerInfo;
-
-  const handleBackClick = () => {
-    router.back();
-  };
-
-  const handleSettingsClick = () => {
-    console.log('설정클릭');
   };
 
   return (
-    <HeaderWrapper className="bg-white">
-      <div className="flex items-center">
-        {showBackButton && (
-          <Button
-            variant="solid"
-            color="transparent"
-            onClick={handleBackClick}
-            className="-ml-2 p-2"
-          >
-            <ChevronLeft size={24} />
-          </Button>
-        )}
-      </div>
+    <HeaderWrapper className="relative flex h-14 items-center justify-between bg-white">
+      {showBackButton ? (
+        <Button
+          variant="solid"
+          color="transparent"
+          onClick={router.back}
+          className="p-2"
+          aria-label="뒤로가기"
+        >
+          <ChevronLeft size={24} />
+        </Button>
+      ) : (
+        <div className="w-10" />
+      )}
 
-      <div className="absolute left-1/2 -translate-x-1/2">
-        <h2 className="text-h4 font-bold">{title}</h2>
-      </div>
+      <h2 className="text-h4 flex-1 text-center font-bold">{title}</h2>
 
-      <div className="flex items-center">
-        {showSettingsButton && (
-          <Button
-            variant="solid"
-            color="transparent"
-            onClick={handleSettingsClick}
-            className="-mr-2 p-2"
-          >
-            <Settings size={24} />
-          </Button>
-        )}
-      </div>
+      <div className="w-10" />
     </HeaderWrapper>
   );
 };

--- a/apps/web/src/components/user/button-sign-out.tsx
+++ b/apps/web/src/components/user/button-sign-out.tsx
@@ -3,8 +3,6 @@ import { FC } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import { Button } from '@/components/ui/button';
-
 import { signOut } from '@/lib/actions/auth';
 
 const ButtonSignOut: FC = () => {
@@ -20,9 +18,12 @@ const ButtonSignOut: FC = () => {
     }
   };
   return (
-    <Button variant="outline" color="secondary" onClick={handleLogout}>
+    <button
+      className="mt-10 mb-4 px-8 text-sm font-bold text-neutral-400 underline"
+      onClick={handleLogout}
+    >
       로그아웃
-    </Button>
+    </button>
   );
 };
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

- 프로필 페이지 리팩토링 #429 

## 📋 작업 내용

- [ ] 프로필 메뉴 명칭 변경
- [ ] ui 리팩토링
- [ ] 로그아웃 버튼 ux 개

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img width="435" height="782" alt="스크린샷 2025-08-01 151026" src="https://github.com/user-attachments/assets/6b70464e-5e50-4d81-a7da-6a1c76e206f3" />


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery가 요약함

프로필 페이지의 헤더, 메뉴, 레이아웃을 전면 개편하여 더 깔끔한 UI와 향상된 탐색 기능을 제공하도록 리팩터링합니다.

개선 사항:
- ProfileHeader를 간소화하고 스타일을 재지정합니다. 설정 버튼을 제거하고, 제목 로직을 통합하며, 레이아웃을 업데이트합니다.
- MenuList를 전면 개편합니다. 섹션 및 항목 이름을 변경하고, 타이포그래피, 간격, 라우팅 레이블을 조정합니다.
- 구매, 판매, 위시리스트에 빠르게 접근할 수 있도록 ProfileShortcutMenu 컴포넌트를 도입합니다.
- 기존 LogoutButton을 미니멀한 ButtonSignOut 텍스트 링크로 대체합니다.
- 업데이트된 테두리, 패딩, 컴포넌트 순서로 프로필 페이지 레이아웃을 미세 조정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the profile page by overhauling its header, menu, and layout for a cleaner UI and improved navigation.

Enhancements:
- Simplify and restyle the ProfileHeader by removing the settings button, unifying title logic, and updating layout.
- Revamp MenuList: rename sections and items, adjust typography, spacing, and routing labels.
- Introduce ProfileShortcutMenu component for quick access to purchases, sales, and wishlist.
- Replace the old LogoutButton with a minimalist ButtonSignOut text link.
- Tweak profile page layout with updated borders, padding, and component order.

</details>