### PR TITLE
[refactor] 프로필 수정 페이지 리팩토링 #430

### DIFF
--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -17,33 +17,32 @@ const ProfilePage = async () => {
   if (!profile) {
     redirect('/auth/signin?redirectTo=/profile');
   }
+
   return (
-    <main className={`h-full overflow-auto bg-white`}>
-      <div className="height-auto w-full bg-white">
-        {/* Profile Card */}
-        <div className="border-b-4 border-neutral-100 py-1">
-          <ProfileCard
-            nickname={profile.nickname || '사용자'}
-            profileImg={profile.profileImg || '/avatar-male.svg'}
-          >
-            <Link href="/profile/edit">
-              <Button variant="outline" size={'sm'}>
-                <Pen />
-                프로필수정
-              </Button>
-            </Link>
-          </ProfileCard>
-        </div>
-
-        <ProfileShortcutMenu />
-
-        <div className="mt-6">
-          <MenuList />
-        </div>
-
-        <ButtonSignOut />
+    <div className="height-auto w-full bg-white">
+      {/* Profile Card */}
+      <div className="border-b-4 border-neutral-100 py-1">
+        <ProfileCard
+          nickname={profile.nickname || '사용자'}
+          profileImg={profile.profileImg || '/avatar-male.svg'}
+        >
+          <Link href="/profile/edit">
+            <Button variant="outline" size={'sm'}>
+              <Pen />
+              프로필수정
+            </Button>
+          </Link>
+        </ProfileCard>
       </div>
-    </main>
+
+      <ProfileShortcutMenu />
+
+      <div className="mt-6">
+        <MenuList />
+      </div>
+
+      <ButtonSignOut />
+    </div>
   );
 };
 

--- a/apps/web/src/components/common/profile/edit/form-edit.tsx
+++ b/apps/web/src/components/common/profile/edit/form-edit.tsx
@@ -91,7 +91,7 @@ const ProfileEditForm = () => {
   }
 
   return (
-    <form className="flex flex-1 flex-col" onSubmit={handleSubmit}>
+    <form className="flex flex-1 flex-col px-4 py-4" id="profile-edit-form" onSubmit={handleSubmit}>
       <ProfileImageUploader
         defaultImage={profile?.profileImg || ''}
         onChange={(e) => {
@@ -100,20 +100,27 @@ const ProfileEditForm = () => {
         }}
       />
 
-      <div className="px-4">
+      <div className="px-4 py-4">
         <NicknameInput
           value={nickname}
           onChange={(e) => setNickname(e.target.value)}
           onValidationChange={handleNicknameValidationChange}
           error={nicknameError}
-          initialValue={profile?.nickname} // 기존 닉네임 전달
+          initialValue={profile?.nickname}
         />
       </div>
 
-      <div className="mb-8 mt-2 px-4">
-        <Button type="submit" fullWidth disabled={isPending || !isNicknameValid}>
-          {isNicknameValid ? (isPending ? '수정 중...' : '수정 하기') : '닉네임 중복 체크'}
-        </Button>
+      <div className="absolute bottom-0 left-0 z-10 w-full bg-white px-8 pb-6">
+        <div className="mx-auto max-w-screen-sm">
+          <Button
+            type="submit"
+            form="profile-edit-form"
+            fullWidth
+            disabled={isPending || !isNicknameValid}
+          >
+            {isNicknameValid ? (isPending ? '수정 중...' : '프로필 수정') : '닉네임 중복 체크'}
+          </Button>
+        </div>
       </div>
     </form>
   );

--- a/apps/web/src/components/common/profile/edit/nickname.tsx
+++ b/apps/web/src/components/common/profile/edit/nickname.tsx
@@ -71,8 +71,8 @@ const NicknameInput = ({
   const isCheckButtonDisabled = !value.trim() || isChecking;
 
   return (
-    <div className={`flex flex-col gap-2 ${className}`}>
-      <div className="flex gap-2">
+    <div className={className}>
+      <div className="flex">
         <div className="relative flex-1">
           <input
             type="text"
@@ -81,7 +81,7 @@ const NicknameInput = ({
             onChange={handleInputChange}
             placeholder={placeholder}
             maxLength={12}
-            className={`h-12 w-full rounded-md border px-4 pr-10 transition-colors ${
+            className={`h-12 w-full rounded-l-md border px-4 pr-10 transition-colors ${
               error
                 ? 'border-danger-500 focus:ring-danger-500/20'
                 : checkResult?.available
@@ -89,26 +89,24 @@ const NicknameInput = ({
                   : checkResult && !checkResult.available
                     ? 'border-danger-500 focus:ring-danger-500/20'
                     : 'focus:border-primary-500 focus:ring-primary-500/20 border-neutral-300'
-            } text-neutral-900 placeholder:text-neutral-400 focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:bg-neutral-50`}
+            } text-neutral-900 placeholder:text-neutral-400 focus:ring-2 focus:outline-none disabled:cursor-not-allowed disabled:bg-neutral-50`}
           />
         </div>
 
-        {/* 중복확인 버튼 */}
         <button
           type="button"
           onClick={handleCheckClick}
           disabled={isCheckButtonDisabled}
-          className={`rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+          className={`text-m rounded-r-md px-4 py-2 font-medium transition-colors ${
             isCheckButtonDisabled
               ? 'cursor-not-allowed bg-neutral-100 text-neutral-400'
-              : 'bg-primary-500 hover:bg-primary-600 focus:ring-primary-500/20 text-white focus:ring-2'
+              : 'focus:ring-primary-500/20 bg-neutral-800 text-white focus:ring-2 active:bg-neutral-800'
           } focus:outline-none`}
         >
           {isChecking ? '확인중...' : '중복확인'}
         </button>
       </div>
-      {/* 메시지 영역*/}
-      <p className={`min-h-[1.25rem] text-sm ${getMessageColor()}`}>
+      <p className={`text-primary-500 m-2 min-h-[1.25rem] text-sm ${getMessageColor()}`}>
         {error ||
           (hasChecked && checkResult?.message) ||
           (hasChecked && isSameAsInitial ? '현재 닉네임과 동일합니다.' : '') ||

--- a/apps/web/src/components/common/profile/edit/profile-image-uploader.tsx
+++ b/apps/web/src/components/common/profile/edit/profile-image-uploader.tsx
@@ -51,9 +51,9 @@ const ProfileImageUploader = ({
   };
 
   return (
-    <div className="relative mb-4 mt-8 flex flex-col items-center">
+    <div className="relative mt-8 mb-4 flex flex-col items-center">
       <div className="relative">
-        <ProfileImage src={preview} alt="프로필 이미지" className="size-[150px]" />
+        <ProfileImage src={preview} alt="프로필 이미지" className="size-[130px]" />
         <input
           type="file"
           id={id}
@@ -66,7 +66,7 @@ const ProfileImageUploader = ({
         <button
           type="button"
           onClick={handleButtonClick}
-          className="absolute -bottom-1 -right-1 flex h-11 w-11 items-center justify-center rounded-full border-4 border-white bg-neutral-300"
+          className="absolute -right-1 -bottom-1 flex h-11 w-11 items-center justify-center rounded-full border-4 border-white bg-neutral-300"
           aria-label="프로필 이미지 변경"
         >
           <Pencil className="h-5 w-5 text-white" />


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

- 프로필 수정 페이지 리팩토링 #430 

## 📋 작업 내용

- ui 리팩토

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img width="588" height="909" alt="스크린샷 2025-08-01 163800" src="https://github.com/user-attachments/assets/53a8e0de-51c2-477f-b17b-b6dd95df9050" />


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

프로필 보기 및 편집 페이지를 리팩토링하여 레이아웃 구조를 통일하고, 스타일 일관성을 개선하며, 사용자 상호작용 흐름을 강화합니다.

개선 사항:
- 프로필 페이지에서 불필요한 `<main>` 래퍼를 제거하고 컨테이너 마크업을 표준화합니다.
- `ProfileEditForm`에 패딩과 폼 ID를 추가하고, 제출 버튼을 업데이트된 레이블과 함께 고정된 하단 패널에 배치합니다.
- `NicknameInput` 컴포넌트의 스타일을 테두리 반경, 입력 필드 포커스 상태, 버튼 스타일 및 메시지 타이포그래피를 조정하여 수정합니다.
- 프로필 이미지 미리보기 크기를 130px로 조정하고, `ProfileImageUploader`에서 파일 업로드 버튼 위치를 미세 조정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor profile display and edit pages to unify layout structure, improve styling consistency, and enhance user interaction flow.

Enhancements:
- Remove redundant <main> wrapper and standardize container markup in the profile page
- Add padding and form id to ProfileEditForm and position the submit button in a fixed bottom panel with updated label
- Revise NicknameInput component styling by adjusting border radii, input focus states, button styles, and message typography
- Resize profile image preview to 130px and refine file upload button positioning in ProfileImageUploader

</details>