### PR TITLE
[refactor] 카드 ui 수정

### DIFF
--- a/apps/web/src/components/common/auction-card/card.tsx
+++ b/apps/web/src/components/common/auction-card/card.tsx
@@ -80,7 +80,7 @@ const AuctionItemCard = ({
             </p>
             {renderTimeBadge({ hours, minutes, isExpired: isAuctionEnded })}
           </div>
-          <div className="w-fll flex shrink flex-col justify-end gap-2 text-right">
+          <div className="flex w-full shrink flex-col justify-end gap-2 text-right">
             <p className="text-xs leading-3 text-neutral-600" style={{ letterSpacing: '-0.75px' }}>
               현재 입찰가
             </p>

--- a/apps/web/src/components/common/auction-card/card.tsx
+++ b/apps/web/src/components/common/auction-card/card.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link';
 
-import { BadgeBidStatus } from '@/components/common';
 import { Badge } from '@/components/ui/badge';
 import Thumbnail from '@/components/ui/thumbnail';
 
@@ -21,7 +20,7 @@ const renderTimeBadge = ({
 }) => {
   if (isExpired) {
     return (
-      <Badge variant="closed" className="pl-1 font-medium">
+      <Badge variant="closed" className="pl-1 text-xs font-medium">
         ⏱️ 종료됨
       </Badge>
     );
@@ -30,7 +29,7 @@ const renderTimeBadge = ({
   const timeBadgeStyle = hours === '00' && minutes === '00' ? 'closed' : 'tertiary';
 
   return (
-    <Badge variant={timeBadgeStyle} className="pl-1 font-medium">
+    <Badge variant={timeBadgeStyle} className="pl-1 text-xs font-medium">
       ⏱️ {`${hours}:${minutes}`}
     </Badge>
   );
@@ -49,39 +48,45 @@ const AuctionItemCard = ({
   const { hours, minutes, isExpired } = useCountdown(new Date(deadline));
 
   const isAuctionEnded = status === '경매종료' || isExpired;
-  const finalStatus: '경매중' | '경매종료' = isAuctionEnded ? '경매종료' : '경매중';
+  // const finalStatus: '경매중' | '경매종료' = isAuctionEnded ? '경매종료' : '경매중';
   return (
     <Link
       href={`/auction/${id}`}
-      className="relative mb-4 flex w-full items-center justify-between gap-2.5 overflow-hidden"
+      className="relative mb-2 flex w-full items-center justify-between gap-2.5 overflow-hidden"
     >
       <div className="z-auto">
-        <BadgeBidStatus status={finalStatus} />
+        {/* <BadgeBidStatus status={finalStatus} /> */}
         <Thumbnail
           url={thumbnailUrl}
           alt={`${title} 썸네일`}
-          size={106}
-          className="size-26.5"
+          size={86}
+          className="size-24"
           priority={idx! < 5}
           quality={50}
           fetchPriority={idx === 0 ? 'high' : undefined}
         />
       </div>
       <div className="w-full shrink">
-        <p className="leading-5.5 mb-1.5 line-clamp-2 text-lg font-medium text-neutral-900">
+        <p className="leading-5.5 text-h5 mb-1.5 line-clamp-2 font-medium text-neutral-900">
           {title}
         </p>
         <div className="flex justify-between">
           <div className="w-fll flex flex-col justify-evenly gap-2">
-            <p className="text-sm font-medium leading-5 text-neutral-400">
+            <p
+              className="font-regular text-xs leading-3 text-neutral-400"
+              style={{ letterSpacing: '-0.75px' }}
+            >
               시작가 <span className="line-through">{originalPrice.toLocaleString()}</span>
             </p>
             {renderTimeBadge({ hours, minutes, isExpired: isAuctionEnded })}
           </div>
           <div className="w-fll flex shrink flex-col justify-end gap-2 text-right">
-            <p className="leading-5">현재 입찰가</p>
-            <p className="text-h3 text-primary-500 leading-none">
-              <strong className="mr-0.5">{currentPrice.toLocaleString('ko-KR')}</strong>원
+            <p className="text-xs leading-3 text-neutral-600" style={{ letterSpacing: '-0.75px' }}>
+              현재 입찰가
+            </p>
+            <p className="text-h5 text-primary-500 leading-none">
+              <strong className="mr-0.5">{currentPrice.toLocaleString('ko-KR')}</strong>
+              <span className="text-xs">원</span>
             </p>
           </div>
         </div>

--- a/apps/web/src/components/common/auction-card/card.tsx
+++ b/apps/web/src/components/common/auction-card/card.tsx
@@ -72,18 +72,13 @@ const AuctionItemCard = ({
         </p>
         <div className="flex justify-between">
           <div className="w-fll flex flex-col justify-evenly gap-2">
-            <p
-              className="font-regular text-xs leading-3 text-neutral-400"
-              style={{ letterSpacing: '-0.75px' }}
-            >
+            <p className="font-regular text-xs leading-3 text-neutral-400">
               시작가 <span className="line-through">{originalPrice.toLocaleString()}</span>
             </p>
             {renderTimeBadge({ hours, minutes, isExpired: isAuctionEnded })}
           </div>
           <div className="flex w-full shrink flex-col justify-end gap-2 text-right">
-            <p className="text-xs leading-3 text-neutral-600" style={{ letterSpacing: '-0.75px' }}>
-              현재 입찰가
-            </p>
+            <p className="text-xs leading-3 text-neutral-600">현재 입찰가</p>
             <p className="text-h5 text-primary-500 leading-none">
               <strong className="mr-0.5">{currentPrice.toLocaleString('ko-KR')}</strong>
               <span className="text-xs">원</span>

--- a/apps/web/src/components/ui/thumbnail.tsx
+++ b/apps/web/src/components/ui/thumbnail.tsx
@@ -26,7 +26,13 @@ const Thumbnail = ({
   ...props
 }: ThumbnailProps) => {
   return (
-    <div className={cn('overflow-hidden rounded-md border border-neutral-200', className)}>
+    <div
+      className={cn(
+        'flex-shrink-0 overflow-hidden rounded-md border border-neutral-200',
+        className
+      )}
+      style={{ width: `${size}px`, height: `${size}px` }}
+    >
       <Image
         src={url}
         alt={alt}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

카드 ui 수정 #443 

## 📋 작업 내용

- 썸네일 사이즈 변경
- 썸네일 뱃지 제거
- 시작가, 현재가 등 폰트 사이즈 변경


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img width="390" height="913" alt="Screenshot 2025-08-04 at 00 02 46" src="https://github.com/user-attachments/assets/eeace7ec-bd4a-4ba1-b82b-570b7fc03bc2" />


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

썸네일 크기 조정, 상태 배지 제거, 타이포그래피 및 간격 업데이트를 통해 경매 카드 UI를 리팩토링하여 더 깔끔하고 일관된 레이아웃을 구현했습니다.

개선 사항:
- 썸네일 크기를 축소하고 인라인 스타일을 통해 크기를 강제 적용했습니다.
- 카드 헤더에서 경매 상태 배지를 제거했습니다.
- 카드 하단 여백을 줄이고 레이아웃 간격을 조정했습니다.
- 시간 배지, 제목, 시작가, 현재 입찰가의 글꼴 크기 및 자간을 표준화했습니다.
- 배지 타이포그래피를 `text-xs`로 조정하고 텍스트 계층 구조를 업데이트했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the auction card UI by resizing thumbnails, removing the status badge, and updating typography and spacing for a cleaner, more consistent layout

Enhancements:
- Reduce thumbnail size and enforce dimensions via inline styles
- Remove auction status badge from the card header
- Decrease card bottom margin and adjust layout spacing
- Standardize font sizes and letter-spacing for time badge, title, starting price, and current bid
- Adjust badge typography to text-xs and update text hierarchy

</details>