### PR TITLE
refactor:청크 최적화(#456)

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -8,18 +8,18 @@ Sentry.init({
   dsn: 'https://9c0dac06d753dcc69a188ba9e75ef840@o4509634509471744.ingest.us.sentry.io/4509634513928192',
 
   // Add optional integrations for additional features
-  integrations: [Sentry.replayIntegration()],
-
+  // integrations: [Sentry.replayIntegration()],
+  integrations: [],
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
 
   // Define how likely Replay events are sampled.
   // This sets the sample rate to be 10%. You may want this to be 100% while
   // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
+  replaysSessionSampleRate: 0, //0.1
 
   // Define how likely Replay events are sampled when an error occurs.
-  replaysOnErrorSampleRate: 1.0,
+  replaysOnErrorSampleRate: 0, //1.0
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -22,6 +22,6 @@ Sentry.init({
   tracesSampleRate: 1,
   debug: false,
 
-  replaysOnErrorSampleRate: 1.0,
-  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 0, //1.0
+  replaysSessionSampleRate: 0, //0.1
 });


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
swcMinify: true 제거 (next.js에서 기본적으로 제공하는 옵션 지워도 됨)

apps/web/instrumentation-client.ts
apps/web/sentry.client.config.ts
sentry에서 replay를 위한 청크가 중복해서 빌드 되고 있음. 찾아본 결과 replay는 화면녹화인데 지금 규모의 프로젝트에서 replay기능까지는 필요 없을거 같다고 판단하여 replay기능을 비활성화
vendors-6d641ea9: @sentry-internal/replay (36.7 KiB)
vendors-9264661d: @sentry-internal/replay (36.7 KiB)

리엑트 둠이 중복해서 번들링 되는 문제 확인
vendors-ceee2f67: 53.3 kB (Next.js React DOM)
react-ed3e8094: 53.0 kB (독립 React DOM)
Next.js의 내장 React DOM과 직접 설치된 React DOM 패키지가 동시 포함이 되는 문제 Webpack이 두 경로를 별개 모듈로 인식하여 생긴 이슈 해결
React DOM 106 KiB (53.3 + 53.0)

리엑트 데브 툴이 프로덕션 번들에 포함되어 프로덕션 번들시 리엑트 데브 툴 제외하게 수정
React DevTools (Chrome Extension): 71.7 KiB

총 71.7+53+36.7+36.7 = 198.1kib 번들 크기 감소

First Load JS shared by all                                                 312 kB
  ├ chunks/nextjs-50f89d1a-84f91f16a37658a1.js          11.7 kB
  ├ chunks/nextjs-874c1da4-458a77a8252f0059.js        10.1 kB
  ├ chunks/nextjs-ceee2f67-a07b911a1c3aea38.js          53.3 kB
  ├ chunks/nextjs-fab66d53-5fdecca37a768c56.js         16.7 kB
  ├ chunks/sentry-ddecfbf0-933b8d4b3b50bf34.js       10.6 kB
  ├ chunks/vendors-3fb6208f-b5a7147580072bda.js     14.1 kB
  ├ chunks/vendors-a1a9c712-8a5f3e9788aab557.js      16.9 kB
  ├ chunks/vendors-ce170dd4-7344b037e46800c6.js   14.1 kB
  └ other shared chunks (total)                                           164 kB


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

불필요한 옵션 제거, 필요 없는 기능 비활성화, webpack 청킹 개선을 통해 Next.js 웹 앱 번들을 최적화하여 중복 의존성과 전체 번들 크기를 줄입니다.

버그 수정:
- React DOM 및 Sentry Replay 통합의 중복 번들링 방지

개선 사항:
- Next.js 기본 축소 기능을 사용하도록 명시적인 swcMinify 설정 제거
- 트리 쉐이킹 개선을 위해 '@/components' 및 '@/lib'에 대한 경로 별칭 추가
- 프로덕션 빌드에서 React DevTools 주입 비활성화

기타 작업:
- instrumentation 및 클라이언트 구성 파일에서 Sentry Replay 통합을 비활성화하고 재생 샘플 속도를 0으로 설정

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize Next.js web app bundle by removing redundant options, disabling unneeded features, and refining webpack chunking to reduce duplicate dependencies and overall bundle size.

Bug Fixes:
- Prevent duplicate bundling of React DOM and Sentry Replay integration

Enhancements:
- Remove explicit swcMinify setting to rely on Next.js default minification
- Add path aliases for '@/components' and '@/lib' to improve tree-shaking
- Disable React DevTools injection in production builds

Chores:
- Disable Sentry Replay integrations and set replay sample rates to 0 in instrumentation and client config files

</details>