### PR TITLE
[refactor] 채팅방 줄바꿈 이슈

### DIFF
--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useMemo } from 'react';
+
 import { ChatListCard, ChatListCardSkeleton } from '@/components/chat';
 import { FilterTab } from '@/components/common';
 
@@ -9,6 +11,14 @@ import { CHAT_STATUS } from '@/lib/constants/chat';
 
 const Page = () => {
   const { filtered: chatRooms, isLoading, error } = useFilteredChatRooms();
+
+  const sortedChatRooms = useMemo(() => {
+    return [...chatRooms].sort((a, b) => {
+      const aLast = a.messages?.[0]?.sentAt ? new Date(a.messages[0].sentAt).getTime() : 0;
+      const bLast = b.messages?.[0]?.sentAt ? new Date(b.messages[0].sentAt).getTime() : 0;
+      return bLast - aLast;
+    });
+  }, [chatRooms]);
 
   if (isLoading) {
     return (
@@ -30,12 +40,12 @@ const Page = () => {
   return (
     <div className="flex h-full w-full flex-col px-4">
       <FilterTab filterKey={'chatStatus'} items={CHAT_STATUS} />
-      {!chatRooms.length && (
+      {!sortedChatRooms.length && (
         <div className="flex items-center justify-center py-8">
           <div className="text-gray-500">대화 중인 채팅방이 없습니다</div>
         </div>
       )}
-      {chatRooms.map((chat) => {
+      {sortedChatRooms.map((chat) => {
         return <ChatListCard key={chat.id} chatInfo={chat} />;
       })}
     </div>

--- a/apps/web/src/components/auction-detail/item-description.tsx
+++ b/apps/web/src/components/auction-detail/item-description.tsx
@@ -8,7 +8,7 @@ const ItemDescription = ({ item }: ItemInformationProps) => {
   return (
     <section className="py-6">
       <h3 className="mb-2.5 text-base font-bold">상품 설명</h3>
-      <pre className="whitespace-pre-wrap">{item.description}</pre>
+      <div className="whitespace-pre-wrap">{item.description}</div>
     </section>
   );
 };

--- a/apps/web/src/components/chat/chat-list-card.tsx
+++ b/apps/web/src/components/chat/chat-list-card.tsx
@@ -56,7 +56,6 @@ const ChatListCard = ({ chatInfo }: { chatInfo: ChatRoom }) => {
     }
   };
 
-  // TODO: 기능 연결 시 roomId 로 연결 해서 해당 태그 내에서 작성할 것.
   const roomId = chatInfo.id;
   const link = `/chat/${roomId}?auctionId=${auctionId}&interlocutor=${otherUser.nickname}`;
 

--- a/apps/web/src/components/chat/messages/chat-bubble.tsx
+++ b/apps/web/src/components/chat/messages/chat-bubble.tsx
@@ -1,7 +1,7 @@
 import { tv } from 'tailwind-variants';
 
 const style = tv({
-  base: 'inline-block p-3 rounded-xl text-sm break-words',
+  base: 'inline-block p-3 rounded-xl text-sm break-words whitespace-pre-wrap',
   variants: {
     color: {
       secondary: 'bg-primary-50/70 text-primary-950 max-w-3/5',

--- a/apps/web/src/components/chat/messages/chat-container.tsx
+++ b/apps/web/src/components/chat/messages/chat-container.tsx
@@ -22,8 +22,6 @@ const ChatContainer = ({ roomId }: { roomId: string }) => {
     scrollToBottom();
   }, [messages]);
 
-  // TODO: 날짜가 넘어가면 백엔드 측에서 날짜 변경 감지하여 date message 쏘는 거 연결하기
-
   return (
     <div className="scrollbar-hide-y flex flex-1 flex-col overflow-y-auto px-4">
       {messages.map((msg) => {

--- a/apps/web/src/components/chat/product-info-card.tsx
+++ b/apps/web/src/components/chat/product-info-card.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 
+import Link from 'next/link';
+
 import { ProductCardSkeleton } from '@/components/chat';
 import ProductCardError from '@/components/chat/product-card-error';
 import productCardStyle from '@/components/chat/style';
@@ -49,6 +51,7 @@ const ProductInfoCard = ({ auctionId, status }: ProductInfoCardProps) => {
   const price = formatCurrencyWithUnit(currentPrice);
 
   const color = isDone ? 'disabled' : 'primary';
+  const href = !isDone ? `/item/${auction?.id}` : '';
 
   const handleComplete = () => {
     showToast({
@@ -82,12 +85,14 @@ const ProductInfoCard = ({ auctionId, status }: ProductInfoCardProps) => {
     <div className={productCardStyle().wrapper()}>
       <div className={productCardStyle().content()}>
         {auction && auction.thumbnailUrl && auction.thumbnailUrl.length > 0 && (
-          <Thumbnail
-            url={auction.thumbnailUrl}
-            alt={auction.title}
-            className="h-12 w-12 shrink-0"
-            size={60}
-          />
+          <Link href={href}>
+            <Thumbnail
+              url={auction.thumbnailUrl}
+              alt={auction.title}
+              className="h-12 w-12 shrink-0"
+              size={60}
+            />
+          </Link>
         )}
         <p className={productCardStyle().infoBox()}>
           <span className="overflow-hidden truncate whitespace-nowrap text-base font-medium">


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

closes #467 

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷
<img width="388" height="596" alt="스크린샷 2025-08-04 오후 9 29 23" src="https://github.com/user-attachments/assets/14e81197-d27f-44d7-b170-d532b41b8be2" />
<img width="384" height="809" alt="스크린샷 2025-08-04 오후 9 29 47" src="https://github.com/user-attachments/assets/2901ae45-e4a5-45ea-95e0-2162980548f8" />



## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

채팅 및 경매 컴포넌트를 리팩터링하여 서식을 유지하고, 채팅방을 최신순으로 정렬하며, 내비게이션 링크를 개선합니다.

개선 사항:
- whitespace-pre-wrap 스타일을 추가하여 채팅 말풍선 내 줄 바꿈 유지
- <pre> 태그를 스타일이 적용된 <div>로 대체하여 아이템 설명 내 줄 바꿈 유지
- 메모화된 필터를 사용하여 가장 최근 메시지 타임스탬프 순으로 채팅방 정렬
- 활성 경매 썸네일을 상세 페이지로 연결되는 링크로 감싸고, 완료된 경매의 링크는 비활성화
- 채팅 컴포넌트 내 쓸모 없어진 TODO 주석 제거

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor chat and auction components to preserve formatting, order chat rooms by recency, and improve navigation links

Enhancements:
- Preserve line breaks in chat bubbles by adding whitespace-pre-wrap styling
- Preserve line breaks in item descriptions by replacing <pre> with a styled <div>
- Sort chat rooms by most recent message timestamp using a memoized filter
- Wrap active auction thumbnails in links to their detail pages and disable linking for completed auctions
- Remove obsolete TODO comments in chat components

</details>