### PR TITLE
[fix] 채팅방 경매 정보 부분 스켈레톤 수정

### DIFF
--- a/apps/web/src/components/chat/product-card-skeleton.tsx
+++ b/apps/web/src/components/chat/product-card-skeleton.tsx
@@ -10,6 +10,9 @@ const ProductCardSkeleton = () => {
           <div className="h-3 w-1/2 rounded bg-neutral-200" />
         </div>
       </div>
+      <div className={productCardStyle().buttonBox()}>
+        <div className={productCardStyle().button()} />
+      </div>
     </div>
   );
 };

--- a/apps/web/src/components/chat/product-info-card.tsx
+++ b/apps/web/src/components/chat/product-info-card.tsx
@@ -89,8 +89,8 @@ const ProductInfoCard = ({ auctionId, status }: ProductInfoCardProps) => {
             <Thumbnail
               url={auction.thumbnailUrl}
               alt={auction.title}
-              className="h-12 w-12 shrink-0"
-              size={60}
+              className="shrink-0"
+              size={52}
             />
           </Link>
         )}

--- a/apps/web/src/components/chat/style.ts
+++ b/apps/web/src/components/chat/style.ts
@@ -6,6 +6,7 @@ const productCardStyle = tv({
     content: 'flex h-full w-full items-center gap-2',
     infoBox: 'flex min-w-0 flex-1 flex-col',
     buttonBox: 'flex items-center justify-end gap-2',
+    button: 'h-8 px-3 bg-neutral-200 w-1/5 rounded-md',
   },
   variants: {
     loading: {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

closes #469

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

썸네일 크기 수정 및 버튼 플레이스홀더 추가와 관련 스타일 업데이트를 통해 채팅방 경매 정보 스켈레톤을 수정합니다.

버그 수정:
- 채팅 상품 정보 카드 내 썸네일이 size 52를 사용하도록 조정하고, 고정된 h-12 w-12 클래스를 제거합니다.
- 채팅 상품 카드 스켈레톤에 누락된 버튼 플레이스홀더를 추가합니다.

개선 사항:
- 채팅 스타일에 새로운 스켈레톤 버튼 스타일 변형을 도입합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the chat room auction info skeleton by correcting thumbnail dimensions and adding a button placeholder with corresponding style updates

Bug Fixes:
- Adjust thumbnail in chat product info card to use size 52 and remove fixed h-12 w-12 classes
- Add a missing button placeholder in the chat product card skeleton

Enhancements:
- Introduce a new skeleton button style variant in chat styles

</details>