### PR TITLE
[refactor] layout 스타일 grid로 변경

### DIFF
--- a/apps/web/app/auction/layout.tsx
+++ b/apps/web/app/auction/layout.tsx
@@ -1,10 +1,11 @@
-import { AuctionHeader, Container } from '@/components/layout';
+import { AuctionHeader, Container, Navigation } from '@/components/layout';
 
 const AuctionLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <AuctionHeader />
       <Container>{children}</Container>
+      <Navigation />
     </>
   );
 };

--- a/apps/web/app/chat/layout.tsx
+++ b/apps/web/app/chat/layout.tsx
@@ -1,10 +1,11 @@
-import { ChatHeader, Container } from '@/components/layout';
+import { ChatHeader, Container, Navigation } from '@/components/layout';
 
 const layoutChat = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <ChatHeader />
       <Container>{children}</Container>
+      <Navigation />
     </>
   );
 };

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -42,6 +42,7 @@
   * {
     @apply border-border outline-ring/50;
   }
+
   body {
     @apply bg-background text-foreground;
   }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -75,17 +75,10 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
       <body className={pretendard.className}>
         <QueryProvider>
           <UserProvider>
-            <div
-              className="relative mx-auto flex h-[100vh] max-h-screen min-h-screen min-w-[320px] max-w-[480px] flex-col justify-between bg-white"
-              style={{
-                height: '100dvh',
-                minHeight: '-webkit-fill-available',
-              }}
-            >
+            <div className="min-h-fill grid-header-main-nav mx-auto grid h-dvh max-h-dvh min-w-[320px] max-w-[480px] overflow-hidden bg-white">
               {children}
               <Toast />
               <LocationModalProvider />
-              <Navigation />
             </div>
           </UserProvider>
         </QueryProvider>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,7 +1,7 @@
 import CategoriesFilter from '@/components/auction/categories-filter';
 import { CreateAuctionButton } from '@/components/common';
 import { AuctionItemList } from '@/components/common';
-import { MainHeader } from '@/components/layout';
+import { MainHeader, Navigation } from '@/components/layout';
 import Container from '@/components/layout/container';
 
 const Page = () => {
@@ -13,6 +13,7 @@ const Page = () => {
         <AuctionItemList />
         <CreateAuctionButton />
       </Container>
+      <Navigation />
     </>
   );
 };

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,8 +11,8 @@ const Page = () => {
       <Container className="px-4">
         <CategoriesFilter />
         <AuctionItemList />
-        <CreateAuctionButton />
       </Container>
+      <CreateAuctionButton />
       <Navigation />
     </>
   );

--- a/apps/web/app/profile/layout.tsx
+++ b/apps/web/app/profile/layout.tsx
@@ -1,10 +1,11 @@
-import { ProfileHeader } from '@/components/layout';
+import { Navigation, ProfileHeader } from '@/components/layout';
 
 const ProfileLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <ProfileHeader />
       {children}
+      <Navigation />
     </>
   );
 };

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -18,7 +18,7 @@ const ProfilePage = async () => {
   }
 
   return (
-    <Container className="w-fulle flex h-full flex-col space-y-2 bg-neutral-100 px-4 [&>div]:rounded-sm [&>div]:shadow-[0px_2px_8px_0px_rgba(0,0,0,.08)]">
+    <Container className="w-fulle [&>div]:border-1 bg-primary-50/30 flex h-full flex-col space-y-2 px-4 pt-2 [&>div]:rounded-sm [&>div]:border-neutral-100 [&>div]:shadow-[0px_1px_9px_0px_rgba(87,88,254,.11)]">
       <ProfileCard
         nickname={profile.nickname || '사용자'}
         profileImg={profile.profileImg || '/avatar-male.svg'}

--- a/apps/web/app/search/layout.tsx
+++ b/apps/web/app/search/layout.tsx
@@ -1,10 +1,11 @@
-import { Container, SearchHeader } from '@/components/layout';
+import { Container, Navigation, SearchHeader } from '@/components/layout';
 
 const layoutSearch = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <SearchHeader />
       <Container className="px-4">{children}</Container>
+      <Navigation />
     </>
   );
 };

--- a/apps/web/src/components/layout/container.tsx
+++ b/apps/web/src/components/layout/container.tsx
@@ -1,27 +1,17 @@
-import { tv } from 'tailwind-variants';
-
 const Container = ({
   children,
   className = '',
-  noNav = false,
 }: {
   children: React.ReactNode;
   className?: string;
-  noNav?: boolean;
 }) => {
-  const containerStyle = tv({
-    base: 'w-full flex-1 h-full scrollbar-hide-y',
-    variants: {
-      noNav: {
-        true: 'max-h-[calc(100vh-56px)]',
-        false: 'max-h-[calc(100vh)]',
-      },
-    },
-    defaultVariants: {
-      noNav: false,
-    },
-  });
-  return <main className={`${containerStyle({ noNav: noNav })} ${className}`}>{children}</main>;
+  return (
+    <main
+      className={`scrollbar-hide-y scroll-touch h-full w-full overflow-y-auto overscroll-contain ${className}`}
+    >
+      {children}
+    </main>
+  );
 };
 
 export default Container;

--- a/apps/web/src/components/layout/header/profile.tsx
+++ b/apps/web/src/components/layout/header/profile.tsx
@@ -46,9 +46,7 @@ const ProfileHeader = () => {
   });
 
   return (
-    <HeaderWrapper
-      className={cn(`relative ${pathname === '/profile' ? 'bg-neutral-100' : 'bg-white'}`)}
-    >
+    <HeaderWrapper className={cn(`bg-primary-50/30 relative`)}>
       {showBackButton && (
         <Button color={'transparent'} className="!px-0" onClick={() => router.back()}>
           <ChevronLeft />

--- a/apps/web/src/components/layout/navigation.tsx
+++ b/apps/web/src/components/layout/navigation.tsx
@@ -5,7 +5,6 @@ import { usePathname } from 'next/navigation';
 
 import { HouseIcon, MessagesSquare, SearchIcon, UserRoundIcon } from 'lucide-react';
 
-import { cn } from '@/lib/cn';
 import { ROUTES, type NavMenuItem } from '@/lib/constants/routes';
 
 // route 작업 후 수정 필요
@@ -20,17 +19,12 @@ const Navigation = () => {
   const pathname = usePathname();
   const showNavigation = ['/', '/auction', '/search', '/chat', '/profile'].includes(pathname || '');
 
+  if (!showNavigation) {
+    return <div className="h-0 w-full"></div>;
+  }
+
   return (
-    <nav
-      className={cn(
-        `z-50 ${
-          showNavigation
-            ? 'mx-auto h-[76px] w-full min-w-[320px] max-w-[480px] bg-white shadow-[var(--shadow-nav)]'
-            : 'hidden'
-        }`
-      )}
-      suppressHydrationWarning
-    >
+    <nav className="z-50 h-[76px] w-full bg-white shadow-[var(--shadow-nav)]">
       <ul className="flex h-full w-full">
         {NAV_MENU.map(({ name, href, icon: Icon }) => {
           const isActive = pathname === href;

--- a/packages/tailwind-config/shared-styles.css
+++ b/packages/tailwind-config/shared-styles.css
@@ -17,12 +17,8 @@ h6 {
 /* tab 가로 스크롤 스타일 숨김 */
 .scrollbar-hide-x {
   overflow-x: auto;
-  /* 가로 스크롤 가능 */
   overflow-y: hidden;
-  /* 세로 스크롤 숨김 */
   white-space: nowrap;
-  /* 내용이 한 줄로 유지되도록 */
-
   -ms-overflow-style: none;
   /* IE and Edge */
   scrollbar-width: none;
@@ -31,26 +27,54 @@ h6 {
 
 .scrollbar-hide-y {
   overflow-y: auto;
-  /* 가로 스크롤 가능 */
   overflow-x: hidden;
-  /* 세로 스크롤 숨김 */
-
   -ms-overflow-style: none;
   /* IE and Edge */
   scrollbar-width: none;
   /* Firefox */
 }
 
-.scrollbar-hide-x::-webkit-scrollbar {
-  /* 웹킷 기반 브라우저에서 스크롤바 숨기기 */
+/* 웹킷 기반 브라우저에서 스크롤바 숨기기 */
+.scrollbar-hide-x::-webkit-scrollbar,
+.scrollbar-hide-y::-webkit-scrollbar {
   width: 0;
   height: 0;
 }
 
-.scrollbar-hide-y::-webkit-scrollbar {
-  /* 웹킷 기반 브라우저에서 스크롤바 숨기기 */
-  width: 0;
-  height: 0;
+.h-dvh {
+  height: 100vh;
+  height: 100dvh;
+}
+
+.min-h-dvh {
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+.max-h-dvh {
+  max-height: 100vh;
+  max-height: 100dvh;
+}
+
+.min-h-fill {
+  min-height: -webkit-fill-available;
+  min-height: stretch;
+}
+
+.grid-main-nav {
+  grid-template-rows: 1fr auto;
+}
+
+.grid-header-main-nav {
+  grid-template-rows: auto 1fr auto;
+}
+
+.scroll-touch {
+  -webkit-overflow-scrolling: touch;
+}
+
+.overscroll-contain {
+  overscroll-behavior: contain;
 }
 
 @theme {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #457

## 📋 작업 내용

- layout : grid로 수줭

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

전반적인 레이아웃을 CSS 그리드 구조로 리팩터링하여 뷰포트 크기 조정 및 오버플로 동작을 위한 새로운 유틸리티 클래스를 활용하고, 컴포넌트 구현을 단순화하며, 내비게이션 요소를 페이지별 레이아웃으로 재배치합니다.

새로운 기능:
- 동적 뷰포트 높이 및 그리드 구조를 위한 CSS 유틸리티 추가 (h-dvh, min-h-dvh, max-h-dvh, min-h-fill, grid-main-nav, grid-header-main-nav, scroll-touch, overscroll-contain)
- 가로 및 세로 컨테이너 모두에서 스크롤바 숨김 스타일 통일

개선 사항:
- 일관된 행 순서 지정을 위해 root 및 페이지 레이아웃을 flex 대신 CSS 그리드를 사용하도록 리팩터링
- tailwind-variants를 제거하고 오버플로 및 높이 관리를 위한 새로운 유틸리티 클래스를 적용하여 Container 컴포넌트 단순화
- Navigation 컴포넌트를 숨겨져 있을 때 항상 빈 플레이스홀더를 렌더링하고 반환하도록 간소화
- 내비게이션 렌더링을 개별 페이지 및 라우트 레이아웃으로 재배치
- 균일한 배경 유틸리티를 사용하도록 ProfileHeader 래퍼 스타일 업데이트

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the overall layout to leverage a CSS grid structure with new utility classes for viewport sizing and overflow behavior, simplifying component implementations and relocating the navigation element into page-specific layouts

New Features:
- Add CSS utilities for dynamic viewport heights and grid structure (h-dvh, min-h-dvh, max-h-dvh, min-h-fill, grid-main-nav, grid-header-main-nav, scroll-touch, overscroll-contain)
- Unify scrollbar hiding styles across both horizontal and vertical containers

Enhancements:
- Refactor the root and page layouts to use CSS grid instead of flex for consistent row sequencing
- Simplify Container component by removing tailwind-variants and applying new utility classes for overflow and height management
- Streamline Navigation component to always render and return an empty placeholder when hidden
- Relocate Navigation rendering into individual page and route layouts
- Update ProfileHeader wrapper styles to use a uniform background utility

</details>