### PR TITLE
[feat] 메인 페이지에서 종료된 경매 보이지 않기

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,6 +1,5 @@
 import CategoriesFilter from '@/components/auction/categories-filter';
-import { CreateAuctionButton } from '@/components/common';
-import { AuctionItemList } from '@/components/common';
+import { AuctionItemList, CreateAuctionButton } from '@/components/common';
 import { MainHeader, Navigation } from '@/components/layout';
 import Container from '@/components/layout/container';
 
@@ -10,7 +9,7 @@ const Page = () => {
       <MainHeader />
       <Container className="px-4">
         <CategoriesFilter />
-        <AuctionItemList />
+        <AuctionItemList includeCompleted={false} />
       </Container>
       <CreateAuctionButton />
       <Navigation />

--- a/apps/web/src/components/common/auction-card/list.tsx
+++ b/apps/web/src/components/common/auction-card/list.tsx
@@ -17,22 +17,19 @@ import { AuctionStatus } from '@/types/filter';
 
 interface AuctionItemListProps {
   sortOption?: SortOption;
-  includeCompleted?: boolean; // 종료된 경매 포함 여부
+  includeCompleted?: boolean;
   selectedStatuses?: AuctionStatus[];
 }
 
 const AuctionItemList = ({
   sortOption = 'latest',
-  includeCompleted = false, // 기본값은 종료된 경매 미포함
+  includeCompleted = false,
   selectedStatuses,
 }: AuctionItemListProps) => {
   const selectedCategoryId = useFilterStore((state) => state.selectedItems.category);
 
-  // 정렬은 Zustand 전역 상태로 관리 (헤더와 공유)
   const selectedLocationName = useLocationStore((state) => state.selectedLocation.locationName);
-  includeCompleted = true;
 
-  // useAuctions 훅을 사용하여 경매 목록 조회 (카테고리 ID로 필터링)
   const {
     data: auctionsData,
     isLoading,
@@ -47,14 +44,21 @@ const AuctionItemList = ({
     includeCompleted
   );
 
-  // 상태별 필터링
   const filteredData = useMemo(() => {
-    if (!selectedStatuses || !auctionsData?.data) return auctionsData?.data;
+    if (!auctionsData?.data) return [];
 
-    return auctionsData.data.filter((auction) =>
-      selectedStatuses.includes(auction.status as AuctionStatus)
-    );
-  }, [auctionsData?.data, selectedStatuses]);
+    let data = auctionsData.data;
+
+    if (!includeCompleted) {
+      data = data.filter((auction) => auction.status !== 'COMPLETED');
+    }
+
+    if (selectedStatuses && selectedStatuses.length > 0) {
+      data = data.filter((auction) => selectedStatuses.includes(auction.status as AuctionStatus));
+    }
+
+    return data;
+  }, [auctionsData?.data, selectedStatuses, includeCompleted]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
closes #474 

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

`AuctionItemList` 컴포넌트에서 완료된 경매를 숨기는 옵션을 도입하고 이를 메인 페이지에 적용합니다.

새로운 기능:
- 완료된 경매의 가시성을 전환하기 위해 `AuctionItemList`에 `includeCompleted` prop을 추가합니다.
- `page.tsx`에서 `includeCompleted`를 `false`로 설정하여 메인 페이지에서 완료된 경매를 숨깁니다.

개선 사항:
- 완료 및 상태 필터를 단일 `useMemo`로 결합하도록 필터링 로직을 리팩토링합니다.
- 명확성을 위해 상태 변수 이름을 변경하고 `useAuctions` 매개변수를 정리합니다.
- 경매 스켈레톤 렌더링에서 키 명명을 표준화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an option to hide completed auctions in the AuctionItemList component and apply it on the main page

New Features:
- Add includeCompleted prop to AuctionItemList to toggle visibility of completed auctions
- Hide completed auctions on the main page by setting includeCompleted to false in page.tsx

Enhancements:
- Refactor filtering logic to combine completion and status filters in a single useMemo
- Rename state variables and clean up useAuctions parameters for clarity
- Standardize key naming in auction skeleton rendering

</details>