### PR TITLE
[refactor] 프로필 헤더 스타일링 수정

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,7 +3,6 @@ import localFont from 'next/font/local';
 import type { Metadata, Viewport } from 'next';
 
 import Toast from '@/components/common/toast';
-import Navigation from '@/components/layout/navigation';
 
 import LocationModalProvider from '@/providers/location-modal-provider';
 import QueryProvider from '@/providers/query-provider';

--- a/apps/web/src/components/layout/header/profile.tsx
+++ b/apps/web/src/components/layout/header/profile.tsx
@@ -45,8 +45,12 @@ const ProfileHeader = () => {
     },
   });
 
+  const isProfileSubpage = pathname !== '/profile' && pathname.startsWith('/profile');
+
   return (
-    <HeaderWrapper className={cn(`bg-primary-50/30 relative`)}>
+    <HeaderWrapper
+      className={cn(isProfileSubpage ? 'relative bg-white' : 'bg-primary-50/30 relative')}
+    >
       {showBackButton && (
         <Button color={'transparent'} className="!px-0" onClick={() => router.back()}>
           <ChevronLeft />


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

closes #476 

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

프로필 헤더 스타일을 리팩토링하여 중첩된 프로필 경로에는 흰색 배경을 적용하고, 메인 프로필 페이지에서는 반투명한 기본 배경을 유지하도록 했습니다.

개선 사항:
- 현재 경로(pathname)를 기반으로 `isProfileSubpage` 감지 기능 추가
- 페이지가 메인 프로필인지 서브페이지인지에 따라 `ProfileHeader`에서 배경 클래스를 조건부로 적용

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor profile header styling to apply a white background on nested profile routes while retaining the semi-transparent primary background on the main profile page.

Enhancements:
- Add isProfileSubpage detection based on the current pathname
- Conditionally apply background classes in ProfileHeader depending on whether the page is the main profile or a subpage

</details>