### PR TITLE
[fix] pwa layout 수정

### DIFF
--- a/apps/web/app/account/layout.tsx
+++ b/apps/web/app/account/layout.tsx
@@ -4,7 +4,9 @@ const AccountLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <AccountHeader />
-      <Container className="p-3">{children}</Container>
+      <Container className="p-3" noNav>
+        {children}
+      </Container>
     </>
   );
 };

--- a/apps/web/app/address/edit/[id]/page.tsx
+++ b/apps/web/app/address/edit/[id]/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { AddressEditForm } from '@/components/personal-info';
 import { use } from 'react';
+
+import { AddressEditForm } from '@/components/personal-info';
 
 const Page = ({ params }: { params: Promise<{ id: string }> }) => {
   const { id } = use(params);

--- a/apps/web/app/address/layout.tsx
+++ b/apps/web/app/address/layout.tsx
@@ -4,7 +4,9 @@ const AddressLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <AddressHeader />
-      <Container className="p-3">{children}</Container>
+      <Container className="p-3" noNav>
+        {children}
+      </Container>
     </>
   );
 };

--- a/apps/web/app/auction/[id]/edit/page.tsx
+++ b/apps/web/app/auction/[id]/edit/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 
 import ErrorBoundaryWrapper from '@/components/common/error-boundary-wrapper';
+import { Container } from '@/components/layout';
 
 import EditAuctionPage from '@/views/EditAuctionPage';
 
@@ -8,21 +9,23 @@ const Page = async ({ params }: { params: Promise<{ id: string }> }) => {
   const { id } = await params;
 
   return (
-    <ErrorBoundaryWrapper>
-      <Suspense
-        key={id} // 중요: itemId가 변경되면 완전히 새로 렌더링
-        fallback={
-          <div className="flex min-h-screen items-center justify-center">
-            <div className="text-center">
-              <div className="border-primary-500 mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2" />
-              <p className="text-gray-600">경매 정보를 불러오는 중...</p>
+    <Container noNav>
+      <ErrorBoundaryWrapper>
+        <Suspense
+          key={id} // 중요: itemId가 변경되면 완전히 새로 렌더링
+          fallback={
+            <div className="flex min-h-screen items-center justify-center">
+              <div className="text-center">
+                <div className="border-primary-500 mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2" />
+                <p className="text-gray-600">경매 정보를 불러오는 중...</p>
+              </div>
             </div>
-          </div>
-        }
-      >
-        <EditAuctionPage itemId={id} />
-      </Suspense>
-    </ErrorBoundaryWrapper>
+          }
+        >
+          <EditAuctionPage itemId={id} />
+        </Suspense>
+      </ErrorBoundaryWrapper>
+    </Container>
   );
 };
 

--- a/apps/web/app/auction/[id]/layout.tsx
+++ b/apps/web/app/auction/[id]/layout.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const AuctionLayout = async ({ children }: { children: React.ReactNode }) => {
-  return <>{children}</>;
-};
-
-export default AuctionLayout;

--- a/apps/web/app/auction/[id]/page.tsx
+++ b/apps/web/app/auction/[id]/page.tsx
@@ -1,7 +1,12 @@
 import { AuctionDetailContainer } from '@/components/auction-detail';
+import { Container } from '@/components/layout';
 
 const Page = () => {
-  return <AuctionDetailContainer />;
+  return (
+    <Container noNav noHead>
+      <AuctionDetailContainer />
+    </Container>
+  );
 };
 
 export default Page;

--- a/apps/web/app/auction/createAuction/page.tsx
+++ b/apps/web/app/auction/createAuction/page.tsx
@@ -1,7 +1,13 @@
+import { Container } from '@/components/layout';
+
 import CreateAuctionPage from '@/views/CreateAcutionPage';
 
 const Page = () => {
-  return <CreateAuctionPage />;
+  return (
+    <Container noNav>
+      <CreateAuctionPage />
+    </Container>
+  );
 };
 
 export default Page;

--- a/apps/web/app/auction/layout.tsx
+++ b/apps/web/app/auction/layout.tsx
@@ -1,11 +1,10 @@
-import { AuctionHeader, Container, Navigation } from '@/components/layout';
+import { AuctionHeader } from '@/components/layout';
 
 const AuctionLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <AuctionHeader />
-      <Container>{children}</Container>
-      <Navigation />
+      {children}
     </>
   );
 };

--- a/apps/web/app/chat/[id]/layout.tsx
+++ b/apps/web/app/chat/[id]/layout.tsx
@@ -1,5 +1,11 @@
+import { Container } from '@/components/layout';
+
 const layoutChatRoom = ({ children }: { children: React.ReactNode }) => {
-  return <>{children}</>;
+  return (
+    <>
+      <Container noNav>{children}</Container>
+    </>
+  );
 };
 
 export default layoutChatRoom;

--- a/apps/web/app/chat/layout.tsx
+++ b/apps/web/app/chat/layout.tsx
@@ -1,10 +1,10 @@
-import { ChatHeader, Container, Navigation } from '@/components/layout';
+import { ChatHeader, Navigation } from '@/components/layout';
 
 const layoutChat = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <ChatHeader />
-      <Container>{children}</Container>
+      {children}
       <Navigation />
     </>
   );

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 
 import { ChatListCard, ChatListCardSkeleton } from '@/components/chat';
 import { FilterTab } from '@/components/common';
+import { Container } from '@/components/layout';
 
 import useFilteredChatRooms from '@/hooks/chat/useFilteredChatRooms';
 
@@ -22,33 +23,39 @@ const Page = () => {
 
   if (isLoading) {
     return (
-      <div className="flex h-full w-full flex-col px-4">
-        <FilterTab filterKey={'chatStatus'} items={CHAT_STATUS} />
-        <ChatListCardSkeleton />
-      </div>
+      <Container>
+        <div className="flex h-full w-full flex-col px-4">
+          <FilterTab filterKey={'chatStatus'} items={CHAT_STATUS} />
+          <ChatListCardSkeleton />
+        </div>
+      </Container>
     );
   }
 
   if (error) {
     return (
-      <div className="flex items-center justify-center py-8">
-        <div className="text-gray-500">채팅방 목록을 불러오는데 실패했습니다</div>
-      </div>
+      <Container>
+        <div className="flex items-center justify-center py-8">
+          <div className="text-gray-500">채팅방 목록을 불러오는데 실패했습니다</div>
+        </div>
+      </Container>
     );
   }
 
   return (
-    <div className="flex h-full w-full flex-col px-4">
-      <FilterTab filterKey={'chatStatus'} items={CHAT_STATUS} />
-      {!sortedChatRooms.length && (
-        <div className="flex items-center justify-center py-8">
-          <div className="text-gray-500">대화 중인 채팅방이 없습니다</div>
-        </div>
-      )}
-      {sortedChatRooms.map((chat) => {
-        return <ChatListCard key={chat.id} chatInfo={chat} />;
-      })}
-    </div>
+    <Container>
+      <div className="flex h-full w-full flex-col px-4">
+        <FilterTab filterKey={'chatStatus'} items={CHAT_STATUS} />
+        {!sortedChatRooms.length && (
+          <div className="flex items-center justify-center py-8">
+            <div className="text-gray-500">대화 중인 채팅방이 없습니다</div>
+          </div>
+        )}
+        {sortedChatRooms.map((chat) => {
+          return <ChatListCard key={chat.id} chatInfo={chat} />;
+        })}
+      </div>
+    </Container>
   );
 };
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -77,7 +77,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
       <body className={pretendard.className}>
         <QueryProvider>
           <UserProvider>
-            <div className="min-h-fill grid-header-main-nav mx-auto grid h-dvh max-h-dvh min-w-[320px] max-w-[480px] overflow-hidden bg-white">
+            <div className="relative mx-auto h-dvh min-w-[320px] max-w-[480px] overflow-hidden bg-white">
               {children}
               <Toast />
               <LocationModalProvider />

--- a/apps/web/app/profile/layout.tsx
+++ b/apps/web/app/profile/layout.tsx
@@ -4,6 +4,7 @@ const ProfileLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <ProfileHeader />
+
       {children}
       <Navigation />
     </>

--- a/apps/web/app/profile/location/page.tsx
+++ b/apps/web/app/profile/location/page.tsx
@@ -2,7 +2,7 @@ import { Container } from '@/components/layout';
 import { LocationList } from '@/components/personal-info';
 const Page = () => {
   return (
-    <Container className="px-4">
+    <Container noNav>
       <LocationList />
     </Container>
   );

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -17,22 +17,24 @@ const ProfilePage = async () => {
   }
 
   return (
-    <Container className="w-fulle [&>div]:border-1 bg-primary-50/30 flex h-full flex-col space-y-2 px-4 pt-2 [&>div]:rounded-sm [&>div]:border-neutral-100 [&>div]:shadow-[0px_1px_9px_0px_rgba(87,88,254,.11)]">
-      <ProfileCard
-        nickname={profile.nickname || '사용자'}
-        profileImg={profile.profileImg || '/avatar-male.svg'}
-      >
-        <Link href="/profile/edit" className="flex h-10 items-center gap-2 text-sm">
-          <Pen size={16} />
-          프로필 수정
-        </Link>
-      </ProfileCard>
-      <ProfileShortcutMenu />
-      <MenuList />
-      <span className="block w-full">
-        <ButtonSignOut />
-      </span>
-    </Container>
+    <>
+      <Container className="[&>div]:border-1 bg-primary-50/30 space-y-2 px-4 [&>div]:rounded-sm [&>div]:border-neutral-100 [&>div]:shadow-[0px_1px_9px_0px_rgba(87,88,254,.11)]">
+        <ProfileCard
+          nickname={profile.nickname || '사용자'}
+          profileImg={profile.profileImg || '/avatar-male.svg'}
+        >
+          <Link href="/profile/edit" className="flex h-10 items-center gap-2 text-sm">
+            <Pen size={16} />
+            프로필 수정
+          </Link>
+        </ProfileCard>
+        <ProfileShortcutMenu />
+        <MenuList />
+        <span className="mt-4 block w-full">
+          <ButtonSignOut />
+        </span>
+      </Container>
+    </>
   );
 };
 

--- a/apps/web/app/profile/support/page.tsx
+++ b/apps/web/app/profile/support/page.tsx
@@ -1,30 +1,34 @@
+import { Container } from '@/components/layout';
+
 import { qnaList } from '@/constants/profile';
 
 const Page = () => {
   return (
-    <div className="mx-auto max-w-2xl bg-white px-4 py-4">
-      <h1 className="mb-4 px-4 text-2xl font-bold">자주 묻는 질문</h1>
-      <div className="flex flex-col gap-3">
-        {qnaList.map(({ question, answer }, idx) => (
-          <div key={idx} className="rounded-lg border border-gray-200 bg-white p-5">
-            <div className="mb-1 font-semibold text-indigo-700">{question}</div>
-            <div className="text-sm text-gray-800">{answer}</div>
-          </div>
-        ))}
+    <Container noNav>
+      <div className="mx-auto max-w-2xl bg-white px-4 py-4">
+        <h1 className="mb-4 px-4 text-2xl font-bold">자주 묻는 질문</h1>
+        <div className="flex flex-col gap-3">
+          {qnaList.map(({ question, answer }, idx) => (
+            <div key={idx} className="rounded-lg border border-gray-200 bg-white p-5">
+              <div className="mb-1 font-semibold text-indigo-700">{question}</div>
+              <div className="text-sm text-gray-800">{answer}</div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-10 text-center text-xs text-gray-400">
+          추가 문의사항은{' '}
+          <a
+            href="https://docs.google.com/forms/d/e/1FAIpQLScMWkhRBarGwD0Tu7hedNc8XIRYvdJ0BYyNqKBBRyf31XIAtg/viewform?usp=header"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-semibold text-indigo-600 underline"
+          >
+            고객센터
+          </a>
+          로 문의해주세요.
+        </div>
       </div>
-      <div className="mt-10 text-center text-xs text-gray-400">
-        추가 문의사항은{' '}
-        <a
-          href="https://docs.google.com/forms/d/e/1FAIpQLScMWkhRBarGwD0Tu7hedNc8XIRYvdJ0BYyNqKBBRyf31XIAtg/viewform?usp=header"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="font-semibold text-indigo-600 underline"
-        >
-          고객센터
-        </a>
-        로 문의해주세요.
-      </div>
-    </div>
+    </Container>
   );
 };
 

--- a/apps/web/src/components/common/profile/menu-list.tsx
+++ b/apps/web/src/components/common/profile/menu-list.tsx
@@ -7,7 +7,7 @@ import { menuSections } from '@/constants/profile';
 const MenuList = () => (
   <>
     {menuSections.map((section) => (
-      <div key={section.id} className="space-y-3 bg-white px-4 py-5">
+      <div key={section.id} className="space-y-3 bg-white px-4 py-4">
         <h3 className="text-min font-bold text-neutral-400">{section.title}</h3>
         <ul className="space-y-1">
           {section.items.map((item) => (

--- a/apps/web/src/components/layout/container.tsx
+++ b/apps/web/src/components/layout/container.tsx
@@ -1,17 +1,30 @@
+import { tv } from 'tailwind-variants';
+
 const Container = ({
   children,
   className = '',
+  noNav = false,
+  noHead = false,
 }: {
   children: React.ReactNode;
   className?: string;
+  noNav?: boolean;
+  noHead?: boolean;
 }) => {
-  return (
-    <main
-      className={`scrollbar-hide-y scroll-touch h-full w-full overflow-y-auto overscroll-contain ${className}`}
-    >
-      {children}
-    </main>
-  );
+  const containerStyle = tv({
+    base: 'scrollbar-hide-y scroll-touch h-full w-full overflow-y-auto overscroll-contain',
+    variants: {
+      noNav: {
+        true: 'pb-0',
+        false: 'pb-[calc(76px+env(safe-area-inset-bottom))]',
+      },
+      noHead: {
+        true: 'pt-0',
+        false: 'pt-15',
+      },
+    },
+  });
+  return <main className={`${containerStyle({ noHead, noNav })} ${className}`}>{children}</main>;
 };
 
 export default Container;

--- a/apps/web/src/components/layout/header/profile.tsx
+++ b/apps/web/src/components/layout/header/profile.tsx
@@ -48,9 +48,7 @@ const ProfileHeader = () => {
   const isProfileSubpage = pathname !== '/profile' && pathname.startsWith('/profile');
 
   return (
-    <HeaderWrapper
-      className={cn(isProfileSubpage ? 'relative bg-white' : 'bg-primary-50/30 relative')}
-    >
+    <HeaderWrapper className={cn(isProfileSubpage ? 'bg-white' : 'bg-primary-50/30')}>
       {showBackButton && (
         <Button color={'transparent'} className="!px-0" onClick={() => router.back()}>
           <ChevronLeft />

--- a/apps/web/src/components/layout/header/wrapper.tsx
+++ b/apps/web/src/components/layout/header/wrapper.tsx
@@ -10,7 +10,7 @@ const HeaderWrapper = ({ children, className, style }: HeaderWrapperProps) => {
   return (
     <header
       className={cn(
-        'h-15 flex w-full flex-shrink-0 items-center justify-between bg-white px-4 pt-1',
+        'h-15 absolute top-0 z-50 flex w-full flex-shrink-0 items-center justify-between bg-white px-4 pt-1',
         className
       )}
       style={style}

--- a/apps/web/src/components/layout/navigation.tsx
+++ b/apps/web/src/components/layout/navigation.tsx
@@ -20,11 +20,17 @@ const Navigation = () => {
   const showNavigation = ['/', '/auction', '/search', '/chat', '/profile'].includes(pathname || '');
 
   if (!showNavigation) {
-    return <div className="h-0 w-full"></div>;
+    return null;
   }
 
   return (
-    <nav className="z-50 h-[76px] w-full bg-white shadow-[var(--shadow-nav)]">
+    <nav
+      className="absolute bottom-0 left-0 right-0 z-50 bg-white shadow-[var(--shadow-nav)]"
+      style={{
+        height: 'calc(76px + env(safe-area-inset-bottom))',
+        paddingBottom: 'env(safe-area-inset-bottom)',
+      }}
+    >
       <ul className="flex h-full w-full">
         {NAV_MENU.map(({ name, href, icon: Icon }) => {
           const isActive = pathname === href;

--- a/apps/web/src/components/personal-info/account/list.tsx
+++ b/apps/web/src/components/personal-info/account/list.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
+
 import { AccountItem, ButtonBox, ButtonCreate } from '@/components/personal-info';
+
 import { useAccounts } from '@/hooks/queries/accounts';
+
 import { deleteAccount } from '@/lib/actions/account';
 import { useToastStore } from '@/lib/zustand/store';
-import { useQueryClient } from '@tanstack/react-query';
 
 const AccountList = () => {
   const { data: accountList = [], isLoading } = useAccounts();

--- a/apps/web/src/components/user/button-sign-out.tsx
+++ b/apps/web/src/components/user/button-sign-out.tsx
@@ -26,7 +26,7 @@ const ButtonSignOut = () => {
   };
   return (
     <button
-      className="border-b-1 mx-auto mb-8 mt-6 block border-neutral-400 text-sm font-medium leading-4 text-neutral-400"
+      className="border-b-1 mx-auto block border-neutral-400 text-sm font-medium leading-4 text-neutral-400"
       onClick={handleLogout}
     >
       로그아웃

--- a/packages/tailwind-config/shared-styles.css
+++ b/packages/tailwind-config/shared-styles.css
@@ -77,6 +77,12 @@ h6 {
   overscroll-behavior: contain;
 }
 
+@supports (padding: env(safe-area-inset-bottom)) {
+  .pb-safe {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}
+
 @theme {
   /* Primary Colors */
   --color-primary-50: #edf0ff;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
closes #487 

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery에 의한 요약

새로운 Container 컴포넌트에 패딩 및 래퍼 로직을 중앙 집중화하고, 내비게이션 및 헤더 위치를 업데이트하며, 업데이트된 구조를 사용하도록 페이지 및 레이아웃 파일을 리팩토링하여 PWA 레이아웃 불일치를 수정합니다.

버그 수정:
- 이슈 #487을 닫아 PWA 레이아웃 문제 해결

개선 사항:
- `noNav`/`noHead` 변형 및 안전 영역 인셋을 인식하는 패딩을 가진 Container 컴포넌트 도입
- 새로운 Container를 사용하여 콘텐츠를 감싸거나 풀도록 페이지 및 레이아웃 컴포넌트(chat, profile, auction, account, address, createAuction) 리팩토링
- Navigation 및 HeaderWrapper를 절대 위치 지정 및 환경 안전 영역 패딩을 사용하도록 업데이트
- 하단 안전 영역 인셋을 위한 `pb-safe` CSS 유틸리티 추가

잡무:
- `grid` 클래스를 제거하고 크기 제약을 업데이트하여 RootLayout 컨테이너 단순화
- 메뉴 목록 항목 및 로그아웃 버튼의 사소한 UI 간격 조정

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix PWA layout inconsistencies by centralizing padding and wrapper logic in a new Container component, updating navigation and header positioning, and refactoring page and layout files to use the updated structure

Bug Fixes:
- Resolve PWA layout issues by closing issue #487

Enhancements:
- Introduce Container component with noNav/noHead variants and safe-area-inset-aware padding
- Refactor page and layout components (chat, profile, auction, account, address, createAuction) to wrap or un-wrap content using the new Container
- Update Navigation and HeaderWrapper to use absolute positioning and environment-safe-area padding
- Add pb-safe CSS utility for bottom safe-area inset

Chores:
- Simplify RootLayout container by removing grid classes and updating size constraints
- Adjust minor UI spacing in menu-list items and the sign-out button

</details>