### PR TITLE
[fix] 변경된 썸네일 사이즈로 srcset 추가

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -27,7 +27,7 @@ const nextConfig: NextConfig = {
 
   images: {
     formats: ['image/avif', 'image/webp'],
-    imageSizes: [28, 40, 46, 58, 106, 212, 480],
+    imageSizes: [28, 40, 46, 58, 86, 120, 150, 172, 212, 256, 375],
     deviceSizes: [150, 375, 500],
     minimumCacheTTL: 60 * 60 * 24 * 7,
     remotePatterns: [

--- a/apps/web/src/components/common/auction-card/card.tsx
+++ b/apps/web/src/components/common/auction-card/card.tsx
@@ -48,7 +48,6 @@ const AuctionItemCard = ({
   const { hours, minutes, isExpired } = useCountdown(new Date(deadline), 'minute');
 
   const isAuctionEnded = status === '경매종료' || isExpired;
-  // const finalStatus: '경매중' | '경매종료' = isAuctionEnded ? '경매종료' : '경매중';
   return (
     <Link
       href={`/auction/${id}`}
@@ -60,7 +59,7 @@ const AuctionItemCard = ({
           alt={`${title} 썸네일`}
           size={86}
           priority={idx! < 5}
-          quality={50}
+          quality={75}
           fetchPriority={idx === 0 ? 'high' : undefined}
         />
       </div>

--- a/apps/web/src/components/ui/thumbnail.tsx
+++ b/apps/web/src/components/ui/thumbnail.tsx
@@ -25,6 +25,8 @@ const Thumbnail = ({
   quality = 80,
   ...props
 }: ThumbnailProps) => {
+  console.log('Thumbnail props:', { size, url, devicePixelRatio: window.devicePixelRatio });
+
   return (
     <div
       className={cn(


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- 옥션 카드 수정된 썸네일에 맞춰 srcset 추가

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

Next.js 이미지 구성 및 컴포넌트 설정을 업데이트하여 썸네일 srcset을 업데이트된 크기 요구 사항에 맞게 정렬

개선 사항:
- 정확한 srcset 생성을 위해 Next.js imageSizes를 확장하여 새로운 썸네일 크기를 포함시켰습니다.
- AuctionItemCard 이미지 품질 설정을 50에서 75로 올렸습니다.
- 디버깅을 위해 Thumbnail 컴포넌트 props의 콘솔 로깅을 추가했습니다.
- AuctionItemCard에서 더 이상 사용되지 않는 주석 처리된 finalStatus 로직을 제거했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align thumbnail srcset with updated size requirements by updating Next.js image configuration and component settings

Enhancements:
- Extend Next.js imageSizes to include new thumbnail dimensions for accurate srcset generation
- Increase AuctionItemCard image quality setting from 50 to 75
- Add console logging of Thumbnail component props for debugging
- Remove obsolete commented-out finalStatus logic in AuctionItemCard

</details>