### PR TITLE
[refactor] 주소등록,계좌등록 뒤로가기 수정

### DIFF
--- a/apps/web/src/components/layout/header/account.tsx
+++ b/apps/web/src/components/layout/header/account.tsx
@@ -16,9 +16,17 @@ const AccountHeader = () => {
       ? '계좌 수정'
       : '계좌 관리';
 
+  const handleOnClick = () => {
+    if (pathname.includes('/create') || pathname.includes('/edit')) {
+      routes.push('/address');
+    } else {
+      routes.push('/profile');
+    }
+  };
+
   return (
     <HeaderWrapper className="justify-start bg-white">
-      <Button variant="solid" color="transparent" onClick={() => routes.back()}>
+      <Button variant="solid" color="transparent" onClick={handleOnClick}>
         <ChevronLeftIcon />
       </Button>
       <h2 className="text-h4 absolute left-1/2 -translate-x-1/2 font-bold">{title}</h2>

--- a/apps/web/src/components/layout/header/account.tsx
+++ b/apps/web/src/components/layout/header/account.tsx
@@ -18,7 +18,7 @@ const AccountHeader = () => {
 
   const handleOnClick = () => {
     if (pathname.includes('/create') || pathname.includes('/edit')) {
-      routes.push('/address');
+      routes.push('/account');
     } else {
       routes.push('/profile');
     }

--- a/apps/web/src/components/layout/header/address.tsx
+++ b/apps/web/src/components/layout/header/address.tsx
@@ -16,9 +16,17 @@ const AddressHeader = () => {
       ? '주소 수정'
       : '주소 관리';
 
+  const handleOnClick = () => {
+    if (pathname.includes('/create') || pathname.includes('/edit')) {
+      routes.push('/address');
+    } else {
+      routes.push('/profile');
+    }
+  };
+
   return (
     <HeaderWrapper className="justify-start bg-white">
-      <Button variant="solid" color="transparent" onClick={() => routes.back()}>
+      <Button variant="solid" color="transparent" onClick={handleOnClick}>
         <ChevronLeftIcon />
       </Button>
       <h2 className="text-h4 absolute left-1/2 -translate-x-1/2 font-bold">{title}</h2>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

주소 등록, 계좌 등록 뒤로가기 수정

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

## Sourcery 요약

AddressHeader 및 AccountHeader 뒤로 가기 버튼 동작을 컨텍스트별 경로로 이동하도록 리팩터링

개선 사항:
- AddressHeader 뒤로 가기 버튼을 생성/편집 페이지에서는 '/address'로, 그 외의 경우에는 '/profile'로 푸시하도록 업데이트
- AccountHeader 뒤로 가기 버튼을 생성/편집 페이지에서는 '/account'로, 그 외의 경우에는 '/profile'로 푸시하도록 업데이트

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor AddressHeader and AccountHeader back button behavior to navigate to context-specific routes

Enhancements:
- Update AddressHeader back button to push '/address' on create/edit pages or '/profile' otherwise
- Update AccountHeader back button to push '/account' on create/edit pages or '/profile' otherwise

</details>